### PR TITLE
module for configuring rxnetty

### DIFF
--- a/iep-module-rxnetty/src/main/java/com/netflix/iep/rxnetty/RxNettyModule.java
+++ b/iep-module-rxnetty/src/main/java/com/netflix/iep/rxnetty/RxNettyModule.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.rxnetty;
+
+
+import com.google.inject.AbstractModule;
+import iep.io.reactivex.netty.RxNetty;
+import iep.io.reactivex.netty.spectator.SpectatorEventsListenerFactory;
+
+
+public class RxNettyModule extends AbstractModule {
+
+  @Override protected void configure() {
+    RxNetty.useMetricListenersFactory(new SpectatorEventsListenerFactory());
+  }
+}

--- a/iep-module-rxnetty/src/main/resources/META-INF/services/com.google.inject.Module
+++ b/iep-module-rxnetty/src/main/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.iep.rxnetty.RxNettyModule

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -30,6 +30,7 @@ object MainBuild extends Build {
       `iep-jmxport`,
       `iep-karyon`,
       `iep-launcher`,
+      `iep-module-rxnetty`,
       `iep-nflxenv`,
       `iep-rxhttp`)
     .settings(buildSettings: _*)
@@ -95,6 +96,15 @@ object MainBuild extends Build {
   lazy val `iep-launcher` = project
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
+
+  lazy val `iep-module-rxnetty` = project
+    .settings(buildSettings: _*)
+    .settings(libraryDependencies ++= commonDeps)
+    .settings(libraryDependencies ++= Seq(
+      Dependencies.guice,
+      Dependencies.rxnettySpectator,
+      Dependencies.slf4jApi
+    ))
 
   lazy val `iep-nflxenv` = project
     .settings(buildSettings: _*)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   val rxjava          = "com.netflix.iep-shadow" % "iep-rxjava" % "1.0.6"
   val rxnetty         = "com.netflix.iep-shadow" % "iep-rxnetty" % "0.4.6"
   val rxnettyCtxts    = "com.netflix.iep-shadow" % "iep-rxnetty-contexts" % "0.4.6"
+  val rxnettySpectator= "com.netflix.iep-shadow" % "iep-rxnetty-spectator" % "0.4.6"
   val scalaLibrary    = "org.scala-lang" % "scala-library" % scala
   val scalaLibraryAll = "org.scala-lang" % "scala-library-all" % scala
   val scalaLogging    = "com.typesafe.scala-logging" % "scala-logging_2.11" % "3.1.0"


### PR DESCRIPTION
Right now all it does is set it to use the spectator
metrics listener:

https://github.com/ReactiveX/RxNetty/tree/0.x/rxnetty-spectator