### PR TITLE
Return an empty list of servers if there are no servers in the registry

### DIFF
--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerEntry.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerEntry.java
@@ -52,6 +52,9 @@ final class ServerEntry {
   List<Server> next(int n) {
     List<Server> out = new ArrayList<>(n);
     int size = servers.size();
+    if (size == 0) {
+      return new ArrayList<>();
+    }
     for (int i = 0, j = nextPos.getAndIncrement(); i < n; ++i, ++j) {
       out.add(servers.get(j % size));
     }


### PR DESCRIPTION
When a vip didn't have any servers registered, a ```java.lang.ArithmeticException``` was being thrown. 