### PR TITLE
explicitly specify all guice deps

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,11 @@ object MainBuild extends Build {
       Dependencies.archaiusCore,
       Dependencies.archaiusLegacy,
       Dependencies.governator,
+      Dependencies.guiceAssist,
       Dependencies.guiceCore,
+      Dependencies.guiceGrapher,
+      Dependencies.guiceMulti,
+      Dependencies.guiceServlet,
       Dependencies.slf4jApi
     ))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,11 @@ object Dependencies {
   val equalsVerifier  = "nl.jqno.equalsverifier" % "equalsverifier" % "1.5.1"
   val eureka          = "com.netflix.eureka" % "eureka-client" % "1.1.150"
   val governator      = "com.netflix.governator" % "governator" % "1.3.3"
+  val guiceAssist     = "com.google.inject.extensions" % "guice-assistedinject" % guice
   val guiceCore       = "com.google.inject" % "guice" % guice
+  val guiceGrapher    = "com.google.inject.extensions" % "guice-grapher" % guice
   val guiceMulti      = "com.google.inject.extensions" % "guice-multibindings" % guice
+  val guiceServlet    = "com.google.inject.extensions" % "guice-servlet" % guice
   val jodaTime        = "joda-time" % "joda-time" % "2.5"
   val karyonAdmin     = "com.netflix.karyon2" % "karyon-admin-web" % "2.2.00-ALPHA7"
   val karyonCore      = "com.netflix.karyon2" % "karyon-core" % "2.2.00-ALPHA7"


### PR DESCRIPTION
To make sure we get a consistent version of guice dependendencies
this change adds an explicit dependency on all guice extensions used
by governator.