### PR TITLE
fix config binding

### DIFF
--- a/iep-config/src/main/java/com/netflix/iep/config/ConfigModule.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/ConfigModule.java
@@ -60,7 +60,6 @@ public class ConfigModule extends AbstractModule {
 
     @Override protected void configure() {
       bind(Config.class).toInstance(ConfigFactory.load());
-      bind(AppConfig.class).asEagerSingleton();
     }
 
     @Provides


### PR DESCRIPTION
```
@400000005538822500e5261c 1) No implementation for com.netflix.archaius.AppConfig was bound.
@400000005538822500e5261c  at com.netflix.iep.config.ConfigModule$OverrideModule.configure(ConfigModule.java:63) (via modules: com.netflix.iep.config.ConfigModule -> com.google.inject.util.Modules$OverrideModule -> com.netflix.iep.config.ConfigModule$OverrideModule)
@400000005538822500e56884
@400000005538822500e56c6c 2) A binding to com.netflix.archaius.AppConfig was already configured at com.netflix.iep.config.ConfigModule$OverrideModule.createAppConfig() (via modules: com.netflix.iep.config.ConfigModule -> com.google.inject.util.Modules$OverrideModule -> com.netflix.iep.config.ConfigModule$OverrideModule).
@400000005538822500e5a704  at com.netflix.iep.config.ConfigModule$OverrideModule.configure(ConfigModule.java:63) (via modules: com.netflix.iep.config.ConfigModule -> com.google.inject.util.Modules$OverrideModule -> com.netflix.iep.config.ConfigModule$OverrideModule)
```