### PR TITLE
make archaius2 the override layer for archaius1

### DIFF
--- a/iep-module-archaius1/README.md
+++ b/iep-module-archaius1/README.md
@@ -1,9 +1,27 @@
 
 ## Description
 
-Guice module to configure [archaius1](https://github.com/Netflix/archaius/tree/2.x). This pulls
-in the 2.x archaius-legacy library and loads `application` as a cascaded property set. If you
-want dynamic properties use 2.x, no remote configuration source will be configured.
+Guice module to configure [archaius1](https://github.com/Netflix/archaius). This module will
+setup the override layer (dynamic properties) to the properties found in the archaius2 config.
+In other words, any property set via archaius2 will take precedence over archaius1 properties
+except for properties set via the archaius1 runtime layer.
+
+So properties will get chosen in the following order:
+
+* 1.x runtime
+* 1.x override
+    * 2.x runtime
+    * 2.x override (dynamic properties from platformservice)
+    * 2.x system (System.getProperty)
+    * 2.x environment (System.getenv)
+    * 2.x application
+    * 2.x library
+* 1.x application (nothing loaded to this layer)
+* 1.x library
+
+Note, if accessed via the static methods there is no guarantee the configuration will be setup
+properly yet. If possible inject the `AbstractConfiguration` to ensure that setup is complete
+before use.
 
 This is mostly for backwards compatibility when using libraries that have not migrated to
 archaius 2.x yet.

--- a/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius2Listener.java
+++ b/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius2Listener.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius1;
+
+import com.netflix.archaius.Config;
+import com.netflix.archaius.ConfigListener;
+import com.netflix.config.AbstractPollingScheduler;
+import com.netflix.config.PollResult;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Listener that updates the override layer of archaius1 when there are changes to the
+ * archaius2 config.
+ */
+class Archaius2Listener extends AbstractPollingScheduler implements ConfigListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Archaius2Listener.class);
+
+  private final AbstractConfiguration v1config;
+
+  Archaius2Listener(AbstractConfiguration v1config) {
+    this.v1config = v1config;
+  }
+
+  @Override protected void schedule(Runnable runnable) {
+  }
+
+  @Override public void stop() {
+  }
+
+  void update(Config config) {
+    Map<String, Object> props = new HashMap<>();
+    Iterator<String> iter = config.getKeys();
+    while (iter.hasNext()) {
+      String k = iter.next();
+      props.put(k, config.getString(k));
+    }
+    LOGGER.debug("update received with {} properties", props.size());
+    populateProperties(PollResult.createFull(props), v1config);
+  }
+
+  @Override public void onConfigAdded(Config config) {
+    update(config);
+  }
+
+  @Override public void onConfigRemoved(Config config) {
+    update(config);
+  }
+
+  @Override public void onConfigUpdated(Config config) {
+    update(config);
+  }
+
+  @Override public void onError(Throwable throwable, Config config) {
+  }
+}

--- a/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/ArchaiusModule.java
+++ b/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/ArchaiusModule.java
@@ -16,29 +16,17 @@
 package com.netflix.iep.archaius1;
 
 import com.google.inject.AbstractModule;
-import com.netflix.config.ConfigurationManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
+import com.netflix.iep.archaius2.OverrideModule;
+import org.apache.commons.configuration.AbstractConfiguration;
 
 /**
  * Helper for configuring archaius v1.
  */
 public final class ArchaiusModule extends AbstractModule {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ArchaiusModule.class);
-
-  public static void loadProperties(String name) {
-    try {
-      ConfigurationManager.loadAppOverrideProperties(name);
-    } catch (IOException e) {
-      LOGGER.warn("failed to load properties for '" + name + "'");
-    }
-  }
-
   @Override protected void configure() {
-    loadProperties("application");
+    install(new OverrideModule());
+    bind(AbstractConfiguration.class).toProvider(ConfigProvider.class).asEagerSingleton();
   }
 
   @Override public boolean equals(Object obj) {

--- a/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/ConfigProvider.java
+++ b/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/ConfigProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius1;
+
+import com.netflix.archaius.Config;
+import com.netflix.config.ConcurrentCompositeConfiguration;
+import com.netflix.config.ConcurrentMapConfiguration;
+import com.netflix.config.ConfigurationManager;
+import org.apache.commons.configuration.AbstractConfiguration;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+class ConfigProvider implements Provider<AbstractConfiguration> {
+
+  @Inject
+  ConfigProvider(Config config) {
+    AbstractConfiguration v1config = ConfigurationManager.getConfigInstance();
+    ConcurrentMapConfiguration override = new ConcurrentMapConfiguration();
+    if (v1config instanceof ConcurrentCompositeConfiguration) {
+      ((ConcurrentCompositeConfiguration) v1config).addConfigurationAtFront(override, "override");
+    }
+
+    Archaius2Listener listener = new Archaius2Listener(override);
+    config.addListener(listener);
+    listener.update(config);
+  }
+
+  @Override public AbstractConfiguration get() {
+    return ConfigurationManager.getConfigInstance();
+  }
+}

--- a/iep-module-archaius1/src/test/java/com/netflix/iep/archaius1/ArchaiusModuleTest.java
+++ b/iep-module-archaius1/src/test/java/com/netflix/iep/archaius1/ArchaiusModuleTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius1;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import com.netflix.archaius.Config;
+import com.netflix.archaius.annotations.OverrideLayer;
+import com.netflix.archaius.annotations.RuntimeLayer;
+import com.netflix.archaius.config.DefaultSettableConfig;
+import com.netflix.archaius.config.SettableConfig;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.iep.archaius2.OverrideModule;
+import com.typesafe.config.ConfigFactory;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class ArchaiusModuleTest {
+
+  private Module overrideModule = new AbstractModule() {
+    @Override protected void configure() {
+      bind(com.typesafe.config.Config.class).toInstance(ConfigFactory.parseString("a=b\nc=d"));
+
+      DefaultSettableConfig dynamic = new DefaultSettableConfig();
+      dynamic.setProperty("c", "dynamic");
+
+      bind(DefaultSettableConfig.class).annotatedWith(OverrideLayer.class).toInstance(dynamic);
+      bind(Config.class).annotatedWith(OverrideLayer.class).toInstance(dynamic);
+    }
+  };
+
+  private Module testModule = Modules.override(new ArchaiusModule(), new OverrideModule()).with(overrideModule);
+
+  @Before
+  public void init() {
+    ConfigurationManager.getConfigInstance().clear();
+  }
+
+  @Test
+  public void getValues() {
+    AbstractConfiguration cfg = Guice.createInjector(testModule).getInstance(AbstractConfiguration.class);
+    Assert.assertEquals("b", cfg.getString("a"));
+    Assert.assertEquals("dynamic", cfg.getString("c"));
+  }
+
+  @Test
+  public void getValueRuntime() {
+    Key<SettableConfig> key = Key.get(SettableConfig.class, RuntimeLayer.class);
+    Injector injector = Guice.createInjector(testModule);
+    SettableConfig runtime = injector.getInstance(key);
+    AbstractConfiguration root = injector.getInstance(AbstractConfiguration.class);
+
+    Assert.assertEquals("b", root.getString("a"));
+    Assert.assertEquals("dynamic", root.getString("c"));
+
+    runtime.setProperty("a", "runtime");
+    runtime.setProperty("c", "runtime");
+    Assert.assertEquals("runtime", root.getString("a"));
+    Assert.assertEquals("runtime", root.getString("c"));
+
+    runtime.clearProperty("a");
+    Assert.assertEquals("b", root.getString("a"));
+    Assert.assertEquals("runtime", root.getString("c"));
+  }
+}

--- a/iep-module-archaius2/src/main/java/com/netflix/iep/archaius2/OverrideModule.java
+++ b/iep-module-archaius2/src/main/java/com/netflix/iep/archaius2/OverrideModule.java
@@ -31,4 +31,12 @@ public final class OverrideModule extends AbstractModule {
         .with(new PlatformServiceModule());
     install(m);
   }
+
+  @Override public boolean equals(Object obj) {
+    return obj != null && getClass().equals(obj.getClass());
+  }
+
+  @Override public int hashCode() {
+    return getClass().hashCode();
+  }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -81,6 +81,7 @@ object MainBuild extends Build {
     .settings(libraryDependencies ++= commonDeps)
 
   lazy val `iep-module-archaius1` = project
+    .dependsOn(`iep-module-archaius2`)
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(


### PR DESCRIPTION
This should allow us to transition loading to archaius2
and also means that dynamic properties from platformservice
will work when using archaius1.