### PR TITLE
allow archaius1 to be used with any v2 config

### DIFF
--- a/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius1Module.java
+++ b/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius1Module.java
@@ -16,16 +16,14 @@
 package com.netflix.iep.archaius1;
 
 import com.google.inject.AbstractModule;
-import com.netflix.iep.archaius2.OverrideModule;
 import org.apache.commons.configuration.Configuration;
 
 /**
  * Helper for configuring archaius v1.
  */
-public final class ArchaiusModule extends AbstractModule {
+public final class Archaius1Module extends AbstractModule {
 
   @Override protected void configure() {
-    install(new OverrideModule());
     bind(Configuration.class).toProvider(ConfigProvider.class).asEagerSingleton();
   }
 

--- a/iep-module-archaius1/src/main/resources/META-INF/services/com.google.inject.Module
+++ b/iep-module-archaius1/src/main/resources/META-INF/services/com.google.inject.Module
@@ -1,1 +1,1 @@
-com.netflix.iep.archaius1.ArchaiusModule
+com.netflix.iep.archaius1.Archaius1Module

--- a/iep-module-archaius1/src/test/java/com/netflix/iep/archaius1/ArchaiusModuleTest.java
+++ b/iep-module-archaius1/src/test/java/com/netflix/iep/archaius1/ArchaiusModuleTest.java
@@ -22,16 +22,14 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 import com.netflix.archaius.Config;
-import com.netflix.archaius.ConfigListener;
+import com.netflix.archaius.annotations.ApplicationLayer;
 import com.netflix.archaius.annotations.OverrideLayer;
 import com.netflix.archaius.annotations.RuntimeLayer;
-import com.netflix.archaius.config.CompositeConfig;
 import com.netflix.archaius.config.DefaultSettableConfig;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.archaius.config.SettableConfig;
+import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.config.ConfigurationManager;
-import com.netflix.iep.archaius2.OverrideModule;
-import com.typesafe.config.ConfigFactory;
 import org.apache.commons.configuration.Configuration;
 import org.junit.Assert;
 import org.junit.Before;
@@ -45,7 +43,11 @@ public class ArchaiusModuleTest {
 
   private Module overrideModule = new AbstractModule() {
     @Override protected void configure() {
-      bind(com.typesafe.config.Config.class).toInstance(ConfigFactory.parseString("a=b\nc=d"));
+      MapConfig cfg = MapConfig.builder()
+          .put("a", "b")
+          .put("c", "d")
+          .build();
+      bind(Config.class).annotatedWith(ApplicationLayer.class).toInstance(cfg);
 
       DefaultSettableConfig dynamic = new DefaultSettableConfig();
       dynamic.setProperty("c", "dynamic");
@@ -55,7 +57,9 @@ public class ArchaiusModuleTest {
     }
   };
 
-  private Module testModule = Modules.override(new ArchaiusModule(), new OverrideModule()).with(overrideModule);
+  private Module testModule = Modules
+      .override(new ArchaiusModule(), new Archaius1Module())
+      .with(overrideModule);
 
   @Before
   public void init() {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -81,12 +81,14 @@ object MainBuild extends Build {
     .settings(libraryDependencies ++= commonDeps)
 
   lazy val `iep-module-archaius1` = project
-    .dependsOn(`iep-module-archaius2`)
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(
+      Dependencies.archaiusCore,
+      Dependencies.archaiusGuice,
       Dependencies.archaiusLegacy,
       Dependencies.guiceCore,
+      Dependencies.guiceMulti,
       Dependencies.slf4jApi
     ))
 


### PR DESCRIPTION
The iep-module-archaius1 no longer forces the use of
iep-module-archaius2.