### PR TITLE
rename class to avoid ambiguity

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val archaiusPersist = "com.netflix.archaius" % "archaius2-persisted2" % archaius
   val archaiusTypesafe= "com.netflix.archaius" % "archaius2-typesafe" % archaius
   val equalsVerifier  = "nl.jqno.equalsverifier" % "equalsverifier" % "1.7.2"
-  val eureka          = "com.netflix.eureka" % "eureka-client" % "1.1.151"
+  val eureka          = "com.netflix.eureka" % "eureka-client" % "1.1.152"
   val governator      = "com.netflix.governator" % "governator" % "1.3.3"
   val guiceAssist     = "com.google.inject.extensions" % "guice-assistedinject" % guice
   val guiceCore       = "com.google.inject" % "guice" % guice


### PR DESCRIPTION
Rename Governator class to GuiceHelper as it is no
longer using governator and is just a minimal helper
for guice4.