### PR TITLE
Add RetryReadTimeouts config option

### DIFF
--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/ClientConfig.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/ClientConfig.java
@@ -210,6 +210,11 @@ class ClientConfig {
     return getInt("RetryDelay", 500);
   }
 
+  /** Whether to retry read timeouts.  */
+  boolean retryReadTimeouts() {
+    return getBoolean("RetryReadTimeouts", true);
+  }
+
   /** User agent string to use when making the request. */
   String userAgent() {
     return getString("UserAgent", "RxHttp");

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/ErrorRetryHandler.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/ErrorRetryHandler.java
@@ -48,7 +48,8 @@ class ErrorRetryHandler implements
 
   @Override
   public Observable<? extends HttpClientResponse<ByteBuf>> call(Throwable throwable) {
-    if (throwable instanceof ConnectException || throwable instanceof ReadTimeoutException) {
+    final boolean retryReadTimeouts = context.config().retryReadTimeouts();
+    if (throwable instanceof ConnectException || throwable instanceof ReadTimeoutException && retryReadTimeouts) {
       context.entry().withAttempt(attempt);
       return context.rxHttp().execute(context);
     }

--- a/iep-rxhttp/src/test/java/com/netflix/iep/http/RxHttpTest.java
+++ b/iep-rxhttp/src/test/java/com/netflix/iep/http/RxHttpTest.java
@@ -454,7 +454,7 @@ public class RxHttpTest {
   }
 
   @Test
-  public void readTimeoutDontRetry() throws Exception {
+  public void readTimeoutDoesntRetry() throws Exception {
     set(client + ".niws.client.ReadTimeout", "100");
     set(client + ".niws.client.RetryReadTimeouts", "false");
     int code = 200;


### PR DESCRIPTION
This PR adds a new config option: RetryReadTimeouts which specifies whether read timeouts should be retried.