### PR TITLE
skip properties with null values

### DIFF
--- a/iep-guice/src/main/java/com/netflix/iep/guice/LifecycleModule.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/LifecycleModule.java
@@ -47,8 +47,14 @@ public class LifecycleModule extends AbstractModule {
         Method postConstruct = AnnotationUtils.getPostConstruct(injectee.getClass());
         if (postConstruct != null) {
           LOGGER.debug("invoking @PostConstruct for {}", injectee.getClass().getName());
-          postConstruct.setAccessible(true);
-          postConstruct.invoke(injectee);
+          try {
+            postConstruct.setAccessible(true);
+            postConstruct.invoke(injectee);
+          } catch (Throwable t) {
+            LOGGER.debug("error calling @PostConstruct (" + postConstruct + ")", t);
+            throw t;
+          }
+          LOGGER.debug("completed @PostConstruct ({})", postConstruct);
         }
 
         Method preDestroy = AnnotationUtils.getPreDestroy(injectee.getClass());

--- a/iep-module-karyon/src/main/java/com/netflix/iep/karyon/KaryonModule.java
+++ b/iep-module-karyon/src/main/java/com/netflix/iep/karyon/KaryonModule.java
@@ -49,7 +49,12 @@ public final class KaryonModule extends AbstractModule {
         Iterator<String> keys = config.getKeys();
         while (keys.hasNext()) {
           String k = keys.next();
-          properties.setProperty(k, config.getString(k));
+          String v = config.getString(k);
+          if (v != null) {
+            properties.setProperty(k, config.getString(k));
+          } else {
+            LOGGER.debug("skipping property '{}' with null value", k);
+          }
         }
         return properties;
       }


### PR DESCRIPTION
Fix NullPointerException if some of the property keys exist
but have a null value.

```
Caused by: java.lang.NullPointerException
        at java.util.Hashtable.put(Hashtable.java:459) ~[?:1.8.0_45]
        at java.util.Properties.setProperty(Properties.java:166) ~[?:1.8.0_45]
        at com.netflix.iep.karyon.KaryonModule$1.overrideProperties(KaryonModule.java:52) ~[iep-module-karyon-0.1.23-SNAPSHOT.jar:0.1.23-SNAPSHOT]
        at netflix.admin.AdminExplorerManager.initialize(AdminExplorerManager.java:44) ~[karyon2-admin-2.7.1.jar:2.7.1]
        ... 83 more
```