### PR TITLE
fix scope issue with eureka module

### DIFF
--- a/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
+++ b/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
@@ -17,6 +17,7 @@ package com.netflix.iep.eureka;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.CloudInstanceConfig;
@@ -41,7 +42,7 @@ public final class EurekaModule extends AbstractModule {
 
   @Override protected void configure() {
     // InstanceInfo
-    bind(InstanceInfo.class).toProvider(EurekaConfigBasedInstanceInfoProvider.class).asEagerSingleton();
+    bind(InstanceInfo.class).toProvider(InstanceInfoProvider.class);
 
     // Needs:
     // * EurekaInstanceConfig

--- a/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
+++ b/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
@@ -17,21 +17,18 @@ package com.netflix.iep.eureka;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.CloudInstanceConfig;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.appinfo.InstanceInfo;
-import com.netflix.appinfo.providers.EurekaConfigBasedInstanceInfoProvider;
 import com.netflix.discovery.DefaultEurekaClientConfig;
 import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.iep.service.Service;
 import org.apache.commons.configuration.Configuration;
 
-import javax.inject.Provider;
 import javax.inject.Singleton;
 
 

--- a/iep-module-eureka/src/main/java/com/netflix/iep/eureka/InstanceInfoProvider.java
+++ b/iep-module-eureka/src/main/java/com/netflix/iep/eureka/InstanceInfoProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.eureka;
+
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.appinfo.providers.EurekaConfigBasedInstanceInfoProvider;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+/**
+ * Wraps EurekaConfigBasedInstanceInfoProvider to avoid scope problems with governator classes
+ * used in eureka.
+ */
+@Singleton
+class InstanceInfoProvider implements Provider<InstanceInfo> {
+
+  private final EurekaConfigBasedInstanceInfoProvider infoProvider;
+
+  @Inject
+  InstanceInfoProvider(EurekaInstanceConfig config) {
+    infoProvider = new EurekaConfigBasedInstanceInfoProvider(config);
+  }
+
+  @Override public InstanceInfo get() {
+    return infoProvider.get();
+  }
+}

--- a/iep-module-eureka/src/test/java/com/netflix/iep/eureka/EurekaModuleTest.java
+++ b/iep-module-eureka/src/test/java/com/netflix/iep/eureka/EurekaModuleTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.eureka;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.discovery.DiscoveryClient;
+import org.apache.commons.configuration.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.URI;
+
+@RunWith(JUnit4.class)
+public class EurekaModuleTest {
+
+  private static final Module archaius = new AbstractModule() {
+    @Override
+    protected void configure() {
+      bind(Configuration.class).toInstance(ConfigurationManager.getConfigInstance());
+    }
+  };
+
+  @Test
+  public void getClient() {
+    Injector injector = Guice.createInjector(archaius, new EurekaModule());
+    DiscoveryClient client = injector.getInstance(DiscoveryClient.class);
+    Assert.assertNotNull(client);
+  }
+
+}

--- a/iep-module-eureka/src/test/resources/eureka-client.properties
+++ b/iep-module-eureka/src/test/resources/eureka-client.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2015 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+netflix.appinfo.validateInstanceId=false
+netflix.appinfo.datacenter=default
+eureka.shouldUseDns=false
+eureka.shouldFetchRegistry=false
+eureka.serviceUrl.default=http://localhost/eureka/v2/


### PR DESCRIPTION
Injector couldn't be created using standalone guice:

```
1) No scope is bound to com.netflix.governator.guice.lazy.LazySingleton.
  at com.netflix.appinfo.providers.EurekaConfigBasedInstanceInfoProvider.class(EurekaConfigBasedInstanceInfoProvider.java:26)
  at com.netflix.iep.eureka.EurekaModule.configure(EurekaModule.java:44)
```

The instance info provider was wrapped to make it only
need the standard classes and a test case was added to
load using Guice without governator.