### PR TITLE
listen on a particular interface

### DIFF
--- a/iep-module-jmxport/src/main/java/com/netflix/iep/jmxport/SingleInterfaceRMIServerSocketFactory.java
+++ b/iep-module-jmxport/src/main/java/com/netflix/iep/jmxport/SingleInterfaceRMIServerSocketFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.jmxport;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.rmi.server.RMIServerSocketFactory;
+
+import javax.net.ServerSocketFactory;
+
+public class SingleInterfaceRMIServerSocketFactory implements RMIServerSocketFactory {
+  private InetAddress address;
+
+  public SingleInterfaceRMIServerSocketFactory(InetAddress address) {
+    this.address = address;
+  }
+
+  @Override public ServerSocket createServerSocket(int port) throws IOException {
+    return ServerSocketFactory.getDefault().createServerSocket(port, 0, address);
+  }
+}


### PR DESCRIPTION
Porting in recent change to platform for jmx behavior.

By default restricts to only listen on localhost so the
user will need to use an ssh proxy to the instance. This
provides better security and auditing. If needed the host
system property can be set to allow connecting directly
to jmx after opening up the port in the instance firewall.