### PR TITLE
name the Configuration binding

### DIFF
--- a/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius1Module.java
+++ b/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius1Module.java
@@ -21,6 +21,7 @@ import com.netflix.archaius.bridge.StaticArchaiusBridgeModule;
 import com.netflix.config.ConfigurationManager;
 import org.apache.commons.configuration.Configuration;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 /**
@@ -35,6 +36,7 @@ public final class Archaius1Module extends AbstractModule {
 
   @Provides
   @Singleton
+  @Named("IEP")
   private Configuration providesConfiguration() {
     return ConfigurationManager.getConfigInstance();
   }

--- a/iep-module-archaius1/src/test/java/com/netflix/iep/archaius1/ArchaiusModuleTest.java
+++ b/iep-module-archaius1/src/test/java/com/netflix/iep/archaius1/ArchaiusModuleTest.java
@@ -20,6 +20,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import com.netflix.archaius.Config;
 import com.netflix.archaius.bridge.StaticAbstractConfiguration;
@@ -32,7 +33,6 @@ import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.archaius.inject.ApplicationLayer;
 import com.netflix.archaius.inject.RemoteLayer;
 import com.netflix.archaius.inject.RuntimeLayer;
-import com.netflix.config.ConfigurationManager;
 import org.apache.commons.configuration.Configuration;
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,6 +44,8 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ArchaiusModuleTest {
+
+  private static final Key<Configuration> IEP_CONFIG = Key.get(Configuration.class, Names.named("IEP"));
 
   private Module overrideModule = new AbstractModule() {
     @Override protected void configure() {
@@ -80,7 +82,7 @@ public class ArchaiusModuleTest {
   @Test
   @Ignore
   public void getValues() {
-    Configuration cfg = Guice.createInjector(testModule).getInstance(Configuration.class);
+    Configuration cfg = Guice.createInjector(testModule).getInstance(IEP_CONFIG);
     Assert.assertEquals("b", cfg.getString("a"));
     Assert.assertEquals("dynamic", cfg.getString("c"));
   }
@@ -90,7 +92,7 @@ public class ArchaiusModuleTest {
     Key<SettableConfig> key = Key.get(SettableConfig.class, RuntimeLayer.class);
     Injector injector = Guice.createInjector(testModule);
     SettableConfig runtime = injector.getInstance(key);
-    Configuration root = injector.getInstance(Configuration.class);
+    Configuration root = injector.getInstance(IEP_CONFIG);
 
     Assert.assertEquals("b", root.getString("a"));
     Assert.assertEquals("dynamic", root.getString("c"));

--- a/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
+++ b/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
@@ -16,6 +16,7 @@
 package com.netflix.iep.eureka;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.multibindings.Multibinder;
 import com.netflix.appinfo.ApplicationInfoManager;
@@ -23,12 +24,14 @@ import com.netflix.appinfo.CloudInstanceConfig;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.appinfo.InstanceInfo;
+import com.netflix.config.ConfigurationManager;
 import com.netflix.discovery.DefaultEurekaClientConfig;
 import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.iep.service.Service;
 import org.apache.commons.configuration.Configuration;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 
@@ -36,6 +39,16 @@ import javax.inject.Singleton;
  * Setup eureka and create binding for DiscoveryClient.
  */
 public final class EurekaModule extends AbstractModule {
+
+  private static class OptionalInjections {
+    @Inject(optional = true)
+    @Named("IEP")
+    private Configuration config;
+
+    Configuration getConfig() {
+      return (config == null) ? ConfigurationManager.getConfigInstance() : config;
+    }
+  }
 
   @Override protected void configure() {
     // InstanceInfo
@@ -68,7 +81,7 @@ public final class EurekaModule extends AbstractModule {
   // Ensure that archaius configuration is setup prior to creating the eureka classes
   @Provides
   @Singleton
-  private EurekaInstanceConfig provideInstanceConfig(Configuration archaius) {
+  private EurekaInstanceConfig provideInstanceConfig(OptionalInjections opts) {
     return new CloudInstanceConfig("netflix.appinfo.");
   }
 

--- a/iep-module-eureka/src/test/java/com/netflix/iep/eureka/EurekaModuleTest.java
+++ b/iep-module-eureka/src/test/java/com/netflix/iep/eureka/EurekaModuleTest.java
@@ -15,33 +15,20 @@
  */
 package com.netflix.iep.eureka;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.Module;
-import com.netflix.config.ConfigurationManager;
 import com.netflix.discovery.DiscoveryClient;
-import org.apache.commons.configuration.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.net.URI;
-
 @RunWith(JUnit4.class)
 public class EurekaModuleTest {
 
-  private static final Module archaius = new AbstractModule() {
-    @Override
-    protected void configure() {
-      bind(Configuration.class).toInstance(ConfigurationManager.getConfigInstance());
-    }
-  };
-
   @Test
   public void getClient() {
-    Injector injector = Guice.createInjector(archaius, new EurekaModule());
+    Injector injector = Guice.createInjector(new EurekaModule());
     DiscoveryClient client = injector.getInstance(DiscoveryClient.class);
     Assert.assertNotNull(client);
   }

--- a/iep-module-karyon/src/test/java/com/netflix/iep/karyon/KaryonModuleTest.java
+++ b/iep-module-karyon/src/test/java/com/netflix/iep/karyon/KaryonModuleTest.java
@@ -16,7 +16,6 @@
 package com.netflix.iep.karyon;
 
 import com.netflix.iep.guice.GuiceHelper;
-import com.netflix.iep.guice.LifecycleModule;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/iep-module-rxnetty/src/main/java/com/netflix/iep/rxnetty/RxNettyModule.java
+++ b/iep-module-rxnetty/src/main/java/com/netflix/iep/rxnetty/RxNettyModule.java
@@ -29,6 +29,7 @@ import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.spectator.SpectatorEventsListenerFactory;
 import org.apache.commons.configuration.Configuration;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 
@@ -36,6 +37,7 @@ public final class RxNettyModule extends AbstractModule {
 
   private static class OptionalInjections {
     @Inject(optional = true)
+    @Named("IEP")
     Configuration configuration;
 
     @Inject(optional = true)

--- a/iep-module-rxnetty/src/test/java/com/netflix/iep/rxnetty/RxNettyModuleTest.java
+++ b/iep-module-rxnetty/src/test/java/com/netflix/iep/rxnetty/RxNettyModuleTest.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.iep.http;
+package com.netflix.iep.rxnetty;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.netflix.iep.rxnetty.RxNettyModule;
+import com.netflix.iep.http.RxHttp;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
There are a number of apps internally that create a binding
of `Configuration` to something other than the main config.
Typically this is a binding for explorers with a small set
of properties. This change specifies a name for the binding
we care about to avoid the conflict.

For our use-cases this will always be an optional injection
and will get the static archaius instance as a fallback.