### PR TITLE
eureka-client 1.2.0

### DIFF
--- a/iep-module-rxnetty/src/test/java/com/netflix/iep/rxnetty/RxNettyModuleTest.java
+++ b/iep-module-rxnetty/src/test/java/com/netflix/iep/rxnetty/RxNettyModuleTest.java
@@ -17,6 +17,7 @@ package com.netflix.iep.rxnetty;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.netflix.iep.eureka.EurekaModule;
 import com.netflix.iep.http.RxHttp;
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,7 +29,7 @@ public class RxNettyModuleTest {
 
   @Test
   public void module() {
-    Injector injector = Guice.createInjector(new RxNettyModule());
+    Injector injector = Guice.createInjector(new RxNettyModule(), new EurekaModule());
     Assert.assertNotNull(injector.getInstance(RxHttp.class));
   }
 }

--- a/iep-module-rxnetty/src/test/resources/eureka-client.properties
+++ b/iep-module-rxnetty/src/test/resources/eureka-client.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2015 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+netflix.appinfo.validateInstanceId=false
+netflix.appinfo.datacenter=default
+eureka.shouldUseDns=false
+eureka.shouldFetchRegistry=false
+eureka.serviceUrl.default=http://localhost/eureka/v2/

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -132,7 +132,7 @@ object MainBuild extends Build {
     ))
 
   lazy val `iep-module-rxnetty` = project
-    .dependsOn(`iep-rxhttp`)
+    .dependsOn(`iep-rxhttp`, `iep-module-eureka` % "test")
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val archaiusPersist = "com.netflix.archaius" % "archaius2-persisted2" % archaius
   val archaiusTypesafe= "com.netflix.archaius" % "archaius2-typesafe" % archaius
   val equalsVerifier  = "nl.jqno.equalsverifier" % "equalsverifier" % "1.7.2"
-  val eureka          = "com.netflix.eureka" % "eureka-client" % "1.1.155"
+  val eureka          = "com.netflix.eureka" % "eureka-client" % "1.2.0"
   val governator      = "com.netflix.governator" % "governator-core" % "1.8.1"
   val guiceAssist     = "com.google.inject.extensions" % "guice-assistedinject" % guice
   val guiceCore       = "com.google.inject" % "guice" % guice


### PR DESCRIPTION
Note, eureka-client was changed to use the standard
`javax.inject` annotations instead of the annotations
from governator. Unfortunately this means that `DiscoveryClient`
can be pulled in via JIT injection, but without the right
settings in place it will throw exceptions about missing
serviceUrl.