### PR TITLE
fix redirect if num retries is set to 0

### DIFF
--- a/iep-rxhttp/src/test/java/com/netflix/iep/http/RxHttpTest.java
+++ b/iep-rxhttp/src/test/java/com/netflix/iep/http/RxHttpTest.java
@@ -335,6 +335,12 @@ public class RxHttpTest {
   }
 
   @Test
+  public void relativeRedirectAndRetries() throws Exception {
+    set(client + ".niws.client.MaxAutoRetriesNextServer", "0");
+    relativeRedirect();
+  }
+
+  @Test
   public void absoluteRedirect() throws Exception {
     int code = 200;
     statusCode.set(code);
@@ -363,6 +369,12 @@ public class RxHttpTest {
     latch.await();
     Assert.assertNull(throwable.get());
     assertEquals(expected, statusCounts);
+  }
+
+  @Test
+  public void absoluteRedirectAndRetries() throws Exception {
+    set(client + ".niws.client.MaxAutoRetriesNextServer", "0");
+    absoluteRedirect();
   }
 
   @Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val archaius   = "2.0.0-rc.30"
+    val archaius   = "2.0.0-rc.32"
     val guice      = "4.0"
     val karyon     = "2.7.3"
     val karyon3    = "3.0.1-rc.8"


### PR DESCRIPTION
If the number of retries was set to 0, then the redirect
handler was never getting added.