### PR TITLE
allow for config specific to environment

### DIFF
--- a/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
+++ b/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
@@ -40,7 +40,14 @@ import java.util.concurrent.TimeUnit;
 public final class PlatformServiceModule extends AbstractModule {
 
   @Override protected void configure() {
-    bind(Config.class).toInstance(ConfigFactory.load());
+  }
+
+  @Provides
+  @Singleton
+  Config providesTypesafeConfig() {
+    final Config baseConfig = ConfigFactory.load();
+    final String envConfigName = "iep-" + baseConfig.getString("netflix.iep.env.environment");
+    return ConfigFactory.load(envConfigName).withFallback(baseConfig);
   }
 
   @Provides

--- a/iep-platformservice/src/main/resources/reference.conf
+++ b/iep-platformservice/src/main/resources/reference.conf
@@ -3,3 +3,55 @@ netflix.iep.archaius {
   sync-init = true
   polling-interval = 30s
 }
+
+netflix.iep.env {
+  ami = "unknown"
+  ami = ${?EC2_AMI_ID}
+
+  vmtype = "unknown"
+  vmtype = ${?EC2_INSTANCE_TYPE}
+
+  zone = "us-east-1c"
+  zone = ${?EC2_AVAILABILITY_ZONE}
+
+  region = "us-east-1"
+  region = ${?EC2_REGION}
+
+  instance-id = "localhost"
+  instance-id = ${?EC2_INSTANCE_ID}
+
+  local-ip = "127.0.0.1"
+  local-ip = ${?EC2_LOCAL_IPV4}
+
+  host = "localhost"
+  host = ${?EC2_LOCAL_IPV4}
+  host = ${?EC2_PUBLIC_HOSTNAME}
+
+  account-id = "unknown"
+  account-id = ${?EC2_OWNER_ID}
+
+  account = "test"
+  account = ${?NETFLIX_ACCOUNT}
+  account-env = "test"
+  account-env = ${?NETFLIX_ACCOUNT_ENV}
+  account-type = "main"
+  account-type = ${?NETFLIX_ACCOUNT_TYPE}
+
+  environment = "test"
+  environment = ${?NETFLIX_ENVIRONMENT}
+
+  vpc-id = "classic"
+  vpc-id = ${?EC2_VPC_ID}
+
+  app = "local"
+  app = ${?NETFLIX_APP}
+
+  cluster = "local-dev"
+  cluster = ${?NETFLIX_CLUSTER}
+
+  asg = "local-dev"
+  asg = ${?NETFLIX_AUTO_SCALE_GROUP}
+
+  stack = "dev"
+  stack = ${?NETFLIX_STACK}
+}

--- a/iep-platformservice/src/test/java/com/netflix/iep/platformservice/PlatformServiceModuleTest.java
+++ b/iep-platformservice/src/test/java/com/netflix/iep/platformservice/PlatformServiceModuleTest.java
@@ -53,6 +53,13 @@ public class PlatformServiceModuleTest {
   private Module testModule = Modules.override(baseModule).with(overrideModule);
 
   @Test
+  public void loadConfig() {
+    PlatformServiceModule m = new PlatformServiceModule();
+    com.typesafe.config.Config c = m.providesTypesafeConfig();
+    Assert.assertEquals("main", c.getString("account-specific-prop"));
+  }
+
+  @Test
   public void getValues() {
     Config cfg = Guice.createInjector(testModule).getInstance(Config.class);
     Assert.assertEquals("b", cfg.getString("a"));

--- a/iep-platformservice/src/test/resources/iep-test.conf
+++ b/iep-platformservice/src/test/resources/iep-test.conf
@@ -1,0 +1,2 @@
+
+account-specific-prop = ${netflix.iep.env.account-type}


### PR DESCRIPTION
For running outside of the main account there are a handful
of properties where we need different settings. The need for
this should get reduced over time as we make things more
consistent.

Also sets up aliases for common env settings with defaults
so it is easier to run locally.