### PR TITLE
fix 404 handler for admin

### DIFF
--- a/iep-module-karyon3/src/main/java/com/netflix/iep/karyon3/CompatModule.java
+++ b/iep-module-karyon3/src/main/java/com/netflix/iep/karyon3/CompatModule.java
@@ -21,6 +21,7 @@ import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.karyon.admin.AdminServer;
 import com.netflix.karyon.admin.HttpServerConfig;
 import com.netflix.karyon.admin.SimpleHttpServer;
+import com.netflix.karyon.admin.rest.AdminServerFallback;
 import com.sun.net.httpserver.HttpHandler;
 
 import javax.inject.Singleton;
@@ -55,6 +56,13 @@ public class CompatModule extends AbstractModule {
     handlers.put("/v1/platform/base/props",   propsHandler);
 
     return new SimpleHttpServer(config, handlers);
+  }
+
+  @Provides
+  @Singleton
+  @AdminServerFallback
+  protected HttpHandler provideFallback() {
+    return new NotFoundHandler();
   }
 
   @Override

--- a/iep-module-karyon3/src/main/java/com/netflix/iep/karyon3/NotFoundHandler.java
+++ b/iep-module-karyon3/src/main/java/com/netflix/iep/karyon3/NotFoundHandler.java
@@ -1,0 +1,20 @@
+package com.netflix.iep.karyon3;
+
+import com.google.common.base.Charsets;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class NotFoundHandler implements HttpHandler {
+  @Override
+  public void handle(HttpExchange exchange) throws IOException {
+    exchange.getResponseHeaders().set("Content-Type", "text/plain");
+    exchange.sendResponseHeaders(404, 0);
+    try (OutputStream out = exchange.getResponseBody()) {
+      String msg = "Resource '" + exchange.getRequestURI().getPath() + "' not found.\n";
+      out.write(msg.getBytes(Charsets.UTF_8));
+    }
+  }
+}

--- a/iep-module-karyon3/src/main/java/com/netflix/iep/karyon3/NotFoundHandler.java
+++ b/iep-module-karyon3/src/main/java/com/netflix/iep/karyon3/NotFoundHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.iep.karyon3;
 
 import com.google.common.base.Charsets;


### PR DESCRIPTION
Default 404 handler doesn't properly close the stream
so we accumulate sockets in a CLOSE_WAIT state.

Also has incorrect content type.