### PR TITLE
retry on UnknownHostException

### DIFF
--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerEntry.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerEntry.java
@@ -54,9 +54,10 @@ final class ServerEntry {
     if (servers.isEmpty()) {
       return Collections.emptyList();
     }
-    List<Server> out = new ArrayList<>(n);
-    int size = servers.size();
-    for (int i = 0, j = nextPos.getAndIncrement(); i < n; ++i, ++j) {
+    final List<Server> out = new ArrayList<>(n);
+    final int size = servers.size();
+    final int start = Integer.remainderUnsigned(nextPos.getAndIncrement(), size);
+    for (int i = 0, j = start; i < n; ++i, ++j) {
       out.add(servers.get(j % size));
     }
     return out;


### PR DESCRIPTION
Since retries are for the next server in the list, an unknown
host exception should be retried as it may only be one bad
server in the list.