### PR TITLE
factory for creating class instance from name

### DIFF
--- a/iep-guice/src/main/java/com/netflix/iep/guice/ClassFactoryProvider.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/ClassFactoryProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.guice;
+
+import com.google.inject.ConfigurationException;
+import com.google.inject.Injector;
+import com.netflix.iep.service.ClassFactory;
+import com.netflix.iep.service.DefaultClassFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+@Singleton
+class ClassFactoryProvider implements Provider<ClassFactory> {
+
+  private final Injector injector;
+
+  @Inject
+  ClassFactoryProvider(Injector injector) {
+    this.injector = injector;
+  }
+
+  @Override
+  public ClassFactory get() {
+    return new DefaultClassFactory(cls -> {
+      try {
+        return injector.getInstance(cls);
+      } catch (ConfigurationException e) {
+        return null;
+      }
+    });
+  }
+}

--- a/iep-guice/src/main/java/com/netflix/iep/guice/LifecycleModule.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/LifecycleModule.java
@@ -18,6 +18,7 @@ package com.netflix.iep.guice;
 import com.google.inject.AbstractModule;
 import com.google.inject.matcher.Matchers;
 import com.google.inject.spi.ProvisionListener;
+import com.netflix.iep.service.ClassFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,7 @@ public class LifecycleModule extends AbstractModule {
     PreDestroyList list = new PreDestroyList();
     bindListener(Matchers.any(), new BindingListener(list));
     bind(PreDestroyList.class).toInstance(list);
+    bind(ClassFactory.class).toProvider(ClassFactoryProvider.class);
   }
 
   @Override public boolean equals(Object obj) {

--- a/iep-guice/src/test/java/com/netflix/iep/guice/GuiceClassFactoryTest.java
+++ b/iep-guice/src/test/java/com/netflix/iep/guice/GuiceClassFactoryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.netflix.iep.service.ClassFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(JUnit4.class)
+public class GuiceClassFactoryTest {
+
+  @Test
+  public void normal() throws Exception {
+    Module module = new AbstractModule() {
+      @Override protected void configure() {
+        bind(String.class).toInstance("foo");
+      }
+    };
+    GuiceHelper helper = new GuiceHelper();
+    helper.start(module);
+
+    Normal obj = helper.getInjector().getInstance(Normal.class);
+    Assert.assertEquals("foo", obj.configClass.v);
+
+    helper.shutdown();
+  }
+
+  @Test
+  public void override() throws Exception {
+    Module module = new AbstractModule() {
+      @Override protected void configure() {
+        bind(String.class).toInstance("foo");
+      }
+    };
+    GuiceHelper helper = new GuiceHelper();
+    helper.start(module);
+
+    WithOverride obj = helper.getInjector().getInstance(WithOverride.class);
+    Assert.assertEquals("bar", obj.configClass.v);
+
+    helper.shutdown();
+  }
+
+  public static class Normal {
+    final TestClass configClass;
+
+    @Inject
+    public Normal(ClassFactory factory) throws Exception {
+      // Class name from configuration settings
+      final String cname = TestClass.class.getName();
+      configClass = factory.newInstance(cname);
+    }
+  }
+
+  public static class WithOverride {
+    final TestClass configClass;
+
+    @Inject
+    public WithOverride(ClassFactory factory) throws Exception {
+      // Class name from configuration settings
+      final String cname = TestClass.class.getName();
+      final Map<Class<?>, Object> overrides = new HashMap<>();
+      overrides.put(String.class, "bar");
+      configClass = factory.newInstance(cname, overrides::get);
+    }
+  }
+
+  public static class TestClass {
+    final String v;
+
+    @Inject
+    public TestClass(String v) {
+      this.v = v;
+    }
+  }
+}

--- a/iep-service/src/main/java/com/netflix/iep/service/ClassFactory.java
+++ b/iep-service/src/main/java/com/netflix/iep/service/ClassFactory.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.service;
+
+import java.util.function.Function;
+
+/**
+ * Utility for creating an instance of a class based on the name. Typically used to create
+ * an instance based on a class name in a config file. This will handle simple constructor
+ * injection cases based on the parameter types. If more fine-grained control is needed, then
+ * use a proper injection framework directly.
+ */
+public interface ClassFactory {
+
+  /**
+   * Create a new instance of a class with the provided name.
+   *
+   * @param name
+   *     Name of the class that can be used with calls such as {@link Class#forName(String)}.
+   * @return
+   *     New instance of the class. Note, a new instance will be created for every call.
+   */
+  default <T> T newInstance(String name) throws ClassNotFoundException {
+    return newInstance(name, c -> null);
+  }
+
+  /**
+   * Create a new instance of a class with the provided name.
+   *
+   * @param name
+   *     Name of the class that can be used with calls such as {@link Class#forName(String)}.
+   * @param overrides
+   *     Override bindings to use for the constructor parameter types.
+   * @return
+   *     New instance of the class. Note, a new instance will be created for every call.
+   */
+  @SuppressWarnings("unchecked")
+  default <T> T newInstance(String name, Function<Class<?>, Object> overrides)
+      throws ClassNotFoundException {
+    final Class<T> cls = (Class<T>) Class.forName(name);
+    return newInstance(cls, overrides);
+  }
+
+  /**
+   * Create a new instance of a class with the provided name.
+   *
+   * @param cls
+   *     Class to use for creating a new instance.
+   * @return
+   *     New instance of the class. Note, a new instance will be created for every call.
+   */
+  default <T> T newInstance(Class<T> cls) {
+    return newInstance(cls, c -> null);
+  }
+
+  /**
+   * Create a new instance of a class with the provided name. Overrides can be used to
+   * provide some local bindings for creating that instance. For example suppose we have a
+   * config block associated with the class name.
+   *
+   * Consider a simple server class:
+   *
+   * <pre>
+   * public class Server {
+   *   private final int port;
+   *
+   *   public Server(Config cfg) {
+   *     port = cfg.getInt("port");
+   *   }
+   *   ...
+   * }
+   * </pre>
+   *
+   * Possible configuration using HOCON:
+   *
+   * <pre>
+   * server.connectors = [
+   *   {
+   *     class = "foo.Server"
+   *     port = 8080
+   *   },
+   *   {
+   *     class = "foo.Server"
+   *     port = 8081
+   *   }
+   * ]
+   * </pre>
+   *
+   * This could be loaded like:
+   *
+   * <pre>
+   * ClassFactory factory = ...
+   * for (Config cfg : config.getConfigList("server.connectors")) {
+   *   Map<Class<?>, Object> overrides = Collections.singletonMap(Config.class, cfg);
+   *   servers.add(factory.newInstance(cfg.getString("class"), overrides));
+   * }
+   * </pre>
+   *
+   * @param cls
+   *     Class to use for creating a new instance.
+   * @param overrides
+   *     Override bindings to use for the constructor parameter types.
+   * @return
+   *     New instance of the class. Note, a new instance will be created for every call.
+   */
+  <T> T newInstance(Class<T> cls, Function<Class<?>, Object> overrides);
+}

--- a/iep-service/src/main/java/com/netflix/iep/service/CreationException.java
+++ b/iep-service/src/main/java/com/netflix/iep/service/CreationException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.service;
+
+public class CreationException extends RuntimeException {
+
+  public CreationException(Class<?> cls) {
+    super(toMsg(cls));
+  }
+
+  public CreationException(Class<?> cls, Throwable t) {
+    super(toMsg(cls), t);
+  }
+
+  public CreationException(String msg) {
+    super(msg);
+  }
+
+  public CreationException(String msg, Throwable t) {
+    super(msg, t);
+  }
+
+  private static String toMsg(Class<?> cls) {
+    return "failed to create new instance of " + cls.getName();
+  }
+}

--- a/iep-service/src/main/java/com/netflix/iep/service/DefaultClassFactory.java
+++ b/iep-service/src/main/java/com/netflix/iep/service/DefaultClassFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.service;
+
+import java.lang.reflect.Constructor;
+import java.util.function.Function;
+
+/**
+ * Simple implementation of ClassInstanceFactory that works for classes that have a no-argument
+ * constructor or a single constructor with explicit bindings provided.
+ */
+public class DefaultClassFactory implements ClassFactory {
+
+  private final Function<Class<?>, Object> bindings;
+
+  public DefaultClassFactory() {
+    this(c -> null);
+  }
+
+  public DefaultClassFactory(Function<Class<?>, Object> bindings) {
+    this.bindings = bindings;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override public <T> T newInstance(Class<T> cls, Function<Class<?>, Object> overrides)
+      throws CreationException {
+      Constructor<?>[] constructors = cls.getDeclaredConstructors();
+      if (constructors.length == 1) {
+        Constructor<?> c = constructors[0];
+        return newInstance(cls, c, c.getParameterTypes(), overrides);
+      } else {
+        for (Constructor<?> c : constructors) {
+          Class<?>[] ptypes = c.getParameterTypes();
+          if (ptypes.length == 0) {
+            return newInstance(cls, c, ptypes, overrides);
+          }
+        }
+        throw new CreationException("class " + cls.getCanonicalName() +
+            " has more than one constructor and does not have a no-argument constructor");
+      }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T newInstance(
+      Class<?> cls,
+      Constructor<?> c,
+      Class<?>[] ptypes,
+      Function<Class<?>, Object> overrides) throws CreationException {
+    try {
+      c.setAccessible(true);
+      if (ptypes.length == 0) {
+        return (T) c.newInstance();
+      } else {
+        Object[] pvalues = new Object[ptypes.length];
+        for (int i = 0; i < ptypes.length; ++i) {
+          pvalues[i] = overrides.apply(ptypes[i]);
+          if (pvalues[i] == null) {
+            pvalues[i] = bindings.apply(ptypes[i]);
+          }
+        }
+
+        return (T) c.newInstance(pvalues);
+      }
+    } catch (Exception e) {
+      throw new CreationException(cls, e);
+    }
+  }
+}

--- a/iep-service/src/test/java/com/netflix/iep/service/DefaultClassFactoryTest.java
+++ b/iep-service/src/test/java/com/netflix/iep/service/DefaultClassFactoryTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.service;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(JUnit4.class)
+public class DefaultClassFactoryTest {
+
+  @Test
+  public void noArgConstructor() {
+    ClassFactory factory = new DefaultClassFactory();
+    HasDefaultConstructor obj = factory.newInstance(HasDefaultConstructor.class);
+    Assert.assertEquals(1, obj.getValue());
+  }
+
+  @Test
+  public void noArgConstructorWithName() throws Exception {
+    ClassFactory factory = new DefaultClassFactory();
+    HasDefaultConstructor obj = factory.newInstance(HasDefaultConstructor.class.getName());
+    Assert.assertEquals(1, obj.getValue());
+  }
+
+  @Test
+  public void singleConstructor() {
+    Map<Class<?>, Object> bindings = new HashMap<>();
+    bindings.put(Integer.TYPE, 1);
+    ClassFactory factory = new DefaultClassFactory(bindings::get);
+    SingleConstructor obj = factory.newInstance(SingleConstructor.class);
+    Assert.assertEquals(1, obj.getValue());
+  }
+
+  @Test
+  public void singlePrivateConstructor() {
+    Map<Class<?>, Object> bindings = new HashMap<>();
+    bindings.put(Integer.TYPE, 1);
+    ClassFactory factory = new DefaultClassFactory(bindings::get);
+    SinglePrivateConstructor obj = factory.newInstance(SinglePrivateConstructor.class);
+    Assert.assertEquals(1, obj.getValue());
+  }
+
+  public static class HasDefaultConstructor {
+    private int value = 0;
+
+    public HasDefaultConstructor() {
+      value = 1;
+    }
+
+    // Make sure other constructors are ignored
+    public HasDefaultConstructor(int value) {
+      this.value = value;
+    }
+
+    public int getValue() {
+      return value;
+    }
+  }
+
+  public static class SingleConstructor {
+    private int value = 0;
+
+    public SingleConstructor(int value) {
+      this.value = value;
+    }
+
+    public int getValue() {
+      return value;
+    }
+  }
+
+  public static class SinglePrivateConstructor {
+    private int value = 0;
+
+    private SinglePrivateConstructor(int value) {
+      this.value = value;
+    }
+
+    public int getValue() {
+      return value;
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -63,6 +63,7 @@ object MainBuild extends Build {
     .settings(buildSettings: _*)
 
   lazy val `iep-guice` = project
+    .dependsOn(`iep-service`)
     .settings(buildSettings: _*)
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(


### PR DESCRIPTION
Helper to use the injector for use-cases where we have class
names specified in the config file. The lib providing the
class needs to follow some simple conventions, but doesn't
need to have any dependency on a specific injection framework.