### PR TITLE
simplify getting total strategy

### DIFF
--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/RxHttp.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/RxHttp.java
@@ -630,14 +630,8 @@ public final class RxHttp {
   }
 
   private PoolLimitDeterminationStrategy getPoolLimitStrategy(ClientConfig clientCfg) {
-    PoolLimitDeterminationStrategy totalStrategy = poolLimits.get(clientCfg.name());
-    if (totalStrategy == null) {
-      totalStrategy = new MaxConnectionsBasedStrategy(clientCfg.maxConnectionsTotal());
-      PoolLimitDeterminationStrategy tmp = poolLimits.putIfAbsent(clientCfg.name(), totalStrategy);
-      if (tmp != null) {
-        totalStrategy = tmp;
-      }
-    }
+    PoolLimitDeterminationStrategy totalStrategy = poolLimits.computeIfAbsent(clientCfg.name(),
+        name -> new MaxConnectionsBasedStrategy(clientCfg.maxConnectionsTotal()));
     return new CompositePoolLimitDeterminationStrategy(
         new MaxConnectionsBasedStrategy(clientCfg.maxConnectionsPerHost()),
         totalStrategy);


### PR DESCRIPTION
Switch to computeIfAbsent to make logic more clear
for getting the total strategy used to limit max
connections.