### PR TITLE
allow name to be overridden

### DIFF
--- a/iep-service/src/main/java/com/netflix/iep/service/AbstractService.java
+++ b/iep-service/src/main/java/com/netflix/iep/service/AbstractService.java
@@ -24,7 +24,7 @@ import javax.annotation.PreDestroy;
  */
 public abstract class AbstractService implements Service {
 
-  private final String name;
+  private String name;
   private volatile State state;
 
   public AbstractService() {


### PR DESCRIPTION
If we use the iep library to create a new WebServer, like so:

```
@Singleton
class WebServerProvider @Inject() (classFactory: ClassFactory, registry: Registry) extends Provider[WebServer] {
  override def get(): WebServer = {
    new WebServer(classFactory, registry, "my_app", 80) {
      override def isHealthy: Boolean = false
    }
  }
}
```

Then the healthcheck API returns the following:

```
{
  "$anon$1": false
}
```

The AbstractService class provides a constructor that can set a name for the service or else it will use the simple class name:

```
  public AbstractService(String name) {
    this.name = (name == null) ? getClass().getSimpleName() : name;
    this.state = State.NEW;
  }
```

However, the way that AbstractService is used as a base for WebServer, there is no opportunity to pass in a name to the AbstractService constructor.

```
class WebServer(classFactory: ClassFactory, registry: Registry, name: String, port: Int)
    extends AbstractService with StrictLogging {
```

Since the AbstractService name is final, it cannot be overridden.

This PR removes the final keyword from the AbstractService name so that it can be overridden in cases where the simple classname detection does not have any particular meaning.

The WebServer class definition could be altered to pass the name into the AbstractService, but I am not sure we want to do that in every case.  The simple class name detection may work well in other cases.
