### PR TITLE
main class for apps that just use ServiceManager

### DIFF
--- a/iep-guice/src/main/java/com/netflix/iep/guice/Args.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/Args.java
@@ -15,7 +15,9 @@
  */
 package com.netflix.iep.guice;
 
+import javax.inject.Inject;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,6 +39,12 @@ public class Args implements Iterable<String> {
 
   private Args(List<String> argv) {
     this.argv = argv;
+  }
+
+  // Needed to all just-in-time binding to work if no explicit argument binding is set.
+  @Inject
+  private Args() {
+    this(Collections.emptyList());
   }
 
   /** Return the argument at the specified position. */

--- a/iep-guice/src/main/java/com/netflix/iep/guice/Args.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/Args.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.guice;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class can be injected to access the command line arguments passed to the
+ * {@link Main} instance.
+ */
+public class Args implements Iterable<String> {
+
+  /**
+   * Create a new instance from an array of command line arguments.
+   */
+  public static Args from(String[] args) {
+    return new Args(Arrays.asList(args));
+  }
+
+  private final List<String> argv;
+
+  private Args(List<String> argv) {
+    this.argv = argv;
+  }
+
+  /** Return the argument at the specified position. */
+  public String get(int i) {
+    return argv.get(i);
+  }
+
+  /** Return true if the list of arguments is empty. */
+  public boolean isEmpty() {
+    return argv.isEmpty();
+  }
+
+  /** Return number of command line arguments. */
+  public int size() {
+    return argv.size();
+  }
+
+  /** Return an array with a copy of the command line arguments. */
+  public String[] asArray() {
+    return argv.toArray(new String[argv.size()]);
+  }
+
+  @Override public Iterator<String> iterator() {
+    return argv.iterator();
+  }
+
+  @Override public String toString() {
+    return argv.stream().collect(Collectors.joining(" "));
+  }
+}

--- a/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.multibindings.Multibinder;
+import com.netflix.iep.service.Service;
+import com.netflix.iep.service.ServiceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * General purpose main class for standalone applications based on {@link GuiceHelper} and
+ * {@link com.netflix.iep.service.ServiceManager}.
+ */
+public class Main {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
+
+  private static final String USE_SERVICE_LOADER_PROP = "netflix.iep.guice.useServiceLoader";
+
+  private static final String EXIT_ON_FAILURE_PROP = "netflix.iep.guice.exitOnFailure";
+
+  private static final String MODULES_PROP = "netflix.iep.guice.modules";
+
+  private static boolean useServiceLoader() {
+    return "true".equals(System.getProperty(USE_SERVICE_LOADER_PROP, "true"));
+  }
+
+  private static boolean exitOnFailure() {
+    return "true".equals(System.getProperty(EXIT_ON_FAILURE_PROP, "true"));
+  }
+
+  private static List<Module> loadExplicitModules() throws Exception {
+    List<Module> modules = new ArrayList<>();
+    String[] cnames = System.getProperty(MODULES_PROP, "").split("[,\\s]+");
+    for (String cname : cnames) {
+      if (!"".equals(cname)) {
+        Class<?> cls = Class.forName(cname);
+        modules.add((Module) cls.newInstance());
+      }
+    }
+    return modules;
+  }
+
+  private GuiceHelper helper;
+
+  Main() {
+  }
+
+  GuiceHelper getHelper() {
+    return helper;
+  }
+
+  void run(String[] args) throws Exception {
+    try {
+      // Setup binding for command line arguments
+      Module argsModule = new AbstractModule() {
+        @Override protected void configure() {
+          Multibinder.newSetBinder(binder(), Service.class);
+          bind(Args.class).toInstance(Args.from(args));
+        }
+      };
+
+      // Load modules present in the classpath
+      List<Module> modules = useServiceLoader()
+          ? GuiceHelper.getModulesUsingServiceLoader()
+          : new ArrayList<>();
+      modules.addAll(loadExplicitModules());
+      modules.add(argsModule);
+
+      // Create injector and start up
+      helper = new GuiceHelper();
+      helper.start(modules);
+      helper.addShutdownHook();
+
+      // Make sure service manager is created
+      helper.getInjector().getInstance(ServiceManager.class);
+      LOGGER.info("service started successfully");
+    } catch (Throwable t) {
+      LOGGER.error("service failed, shutting down", t);
+      if (exitOnFailure()) {
+        System.exit(1);
+      }
+      throw t;
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    (new Main()).run(args);
+  }
+}

--- a/iep-guice/src/test/java/com/netflix/iep/guice/MainTest.java
+++ b/iep-guice/src/test/java/com/netflix/iep/guice/MainTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.guice;
+
+import com.google.inject.ProvisionException;
+import com.netflix.iep.service.ServiceManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class MainTest {
+
+  @BeforeClass
+  public static void beforeClass() {
+    System.setProperty("netflix.iep.guice.exitOnFailure", "false");
+  }
+
+  @Before
+  public void before() {
+    System.setProperty("netflix.iep.guice.useServiceLoader", "true");
+    System.setProperty("netflix.iep.guice.modules", "");
+  }
+
+  @Test
+  public void runWithNoModules() throws Exception {
+    System.setProperty("netflix.iep.guice.useServiceLoader", "false");
+    Main m = new Main();
+    m.run(new String[]{});
+  }
+
+  @Test
+  public void runWithExplicitModules() throws Exception {
+    System.setProperty("netflix.iep.guice.useServiceLoader", "false");
+    System.setProperty("netflix.iep.guice.modules", "com.netflix.iep.guice.TestModule");
+    Main m = new Main();
+    boolean startupFailed = false;
+    try {
+      m.run(new String[]{});
+    } catch (ProvisionException e) {
+      startupFailed = true;
+      Assert.assertEquals("missing required argument", e.getCause().getMessage());
+    } finally {
+      Assert.assertTrue(startupFailed);
+    }
+  }
+
+  @Test
+  public void runWithNoArgs() throws Exception {
+    Main m = new Main();
+    boolean startupFailed = false;
+    try {
+      m.run(new String[]{});
+    } catch (ProvisionException e) {
+      startupFailed = true;
+      Assert.assertEquals("missing required argument", e.getCause().getMessage());
+    } finally {
+      Assert.assertTrue(startupFailed);
+    }
+  }
+
+  @Test
+  public void runWithUp() throws Exception {
+    Main m = new Main();
+    m.run(new String[]{"up"});
+    Assert.assertTrue(m.getHelper().getInjector().getInstance(ServiceManager.class).isHealthy());
+  }
+
+  @Test
+  public void runWithDown() throws Exception {
+    Main m = new Main();
+    m.run(new String[]{"down"});
+    Assert.assertFalse(m.getHelper().getInjector().getInstance(ServiceManager.class).isHealthy());
+  }
+
+  @Test
+  public void runWithFoo() throws Exception {
+    Main m = new Main();
+    boolean startupFailed = false;
+    try {
+      m.run(new String[]{"foo"});
+    } catch (ProvisionException e) {
+      startupFailed = true;
+      Assert.assertEquals("unknown mode: foo", e.getCause().getMessage());
+    } finally {
+      Assert.assertTrue(startupFailed);
+    }
+  }
+}

--- a/iep-guice/src/test/java/com/netflix/iep/guice/TestModule.java
+++ b/iep-guice/src/test/java/com/netflix/iep/guice/TestModule.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import com.netflix.iep.service.Service;
+
+public class TestModule extends AbstractModule {
+  @Override protected void configure() {
+    Multibinder<Service> serviceBinder = Multibinder.newSetBinder(binder(), Service.class);
+    serviceBinder.addBinding().to(TestService.class);
+  }
+}

--- a/iep-guice/src/test/java/com/netflix/iep/guice/TestService.java
+++ b/iep-guice/src/test/java/com/netflix/iep/guice/TestService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.guice;
+
+import com.netflix.iep.service.AbstractService;
+
+import javax.inject.Inject;
+
+public class TestService extends AbstractService {
+
+  private boolean healthy = false;
+
+  @Inject
+  public TestService(Args args) {
+    if (args.isEmpty()) {
+      throw new IllegalArgumentException("missing required argument");
+    } else {
+      switch (args.get(0)) {
+        case "fail":
+          throw new IllegalArgumentException("die");
+        case "up":
+          healthy = true;
+          break;
+        case "down":
+          healthy = false;
+          break;
+        default:
+          throw new IllegalArgumentException("unknown mode: " + args.get(0));
+      }
+    }
+  }
+
+  @Override public boolean isHealthy() {
+    return super.isHealthy() && healthy;
+  }
+
+  @Override protected void startImpl() throws Exception {
+  }
+
+  @Override protected void stopImpl() throws Exception {
+  }
+}

--- a/iep-guice/src/test/resources/META-INF/services/com.google.inject.Module
+++ b/iep-guice/src/test/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.iep.guice.TestModule

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -80,6 +80,7 @@ object MainBuild extends Build {
     .settings(libraryDependencies ++= commonDeps)
     .settings(libraryDependencies ++= Seq(
       Dependencies.guiceCore,
+      Dependencies.guiceMulti,
       Dependencies.slf4jApi
     ))
 


### PR DESCRIPTION
For simple apps that just define a set of Service binding
for use with ServiceManager, the main class is pretty much
the same. This change adds a simple main class that can be
reused for those applications.