### PR TITLE
update to rxnetty 0.4.17

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val eureka     = "1.4.10"
     val guice      = "4.1.0"
     val jackson    = "2.7.4"
-    val rxnetty    = "0.4.16"
+    val rxnetty    = "0.4.17"
     val scala      = "2.11.8"
     val slf4j      = "1.7.21"
     val spectator  = "0.40.0"


### PR DESCRIPTION
This release allows us to work with netty 4.1.x.Final
instead of the older 4.1 beta release. We have seen
soem issues with mixed versions.