### PR TITLE
remove rxnetty metrics module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,6 @@ lazy val `iep-module-rxnetty` = project
     Dependencies.guiceCore,
     Dependencies.rxnettyCore,
     Dependencies.rxnettyCtxts,
-    Dependencies.rxnettySpectator,
     Dependencies.slf4jApi
   ))
 

--- a/iep-module-rxnetty/src/main/java/com/netflix/iep/rxnetty/RxNettyModule.java
+++ b/iep-module-rxnetty/src/main/java/com/netflix/iep/rxnetty/RxNettyModule.java
@@ -26,8 +26,6 @@ import com.netflix.iep.http.BasicServerRegistry;
 import com.netflix.iep.http.EurekaServerRegistry;
 import com.netflix.iep.http.RxHttp;
 import com.netflix.iep.http.ServerRegistry;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.spectator.SpectatorEventsListenerFactory;
 
 import javax.inject.Singleton;
 
@@ -58,7 +56,6 @@ public final class RxNettyModule extends AbstractModule {
   }
 
   @Override protected void configure() {
-    RxNetty.useMetricListenersFactory(new SpectatorEventsListenerFactory());
   }
 
   @Provides


### PR DESCRIPTION
We typically use the http request level metrics to
understand what the clients are doing. The lower level
rxnetty metrics aren't used much and don't follow
the recommended conventions so we would prefer not
to publish them for our apps by default.

An app owner can explicitly enable if they are still
desirable in certain use-cases.