### PR TITLE
fix toString for OrQuery

### DIFF
--- a/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/SpectatorEndpoint.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/SpectatorEndpoint.java
@@ -119,6 +119,24 @@ public class SpectatorEndpoint implements HttpEndpoint {
     public long getCount() {
       return count;
     }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      CounterInfo that = (CounterInfo) o;
+      return count == that.count && tags.equals(that.tags);
+    }
+
+    @Override public int hashCode() {
+      int result = tags.hashCode();
+      result = 31 * result + (int) (count ^ (count >>> 32));
+      return result;
+    }
+
+    @Override public String toString() {
+      return "CounterInfo(" + tags + ", " + count + ")";
+    }
   }
 
   public static class TimerInfo {
@@ -147,6 +165,27 @@ public class SpectatorEndpoint implements HttpEndpoint {
 
     public long getCount() {
       return count;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      TimerInfo timerInfo = (TimerInfo) o;
+      return totalTime == timerInfo.totalTime
+          && count == timerInfo.count
+          && tags.equals(timerInfo.tags);
+    }
+
+    @Override public int hashCode() {
+      int result = tags.hashCode();
+      result = 31 * result + (int) (totalTime ^ (totalTime >>> 32));
+      result = 31 * result + (int) (count ^ (count >>> 32));
+      return result;
+    }
+
+    @Override public String toString() {
+      return "TimerInfo(" + tags + ", " + count + ", " + totalTime + ")";
     }
   }
 
@@ -177,6 +216,27 @@ public class SpectatorEndpoint implements HttpEndpoint {
     public long getCount() {
       return count;
     }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      DistInfo distInfo = (DistInfo) o;
+      return totalAmount == distInfo.totalAmount
+          && count == distInfo.count
+          && tags.equals(distInfo.tags);
+    }
+
+    @Override public int hashCode() {
+      int result = tags.hashCode();
+      result = 31 * result + (int) (totalAmount ^ (totalAmount >>> 32));
+      result = 31 * result + (int) (count ^ (count >>> 32));
+      return result;
+    }
+
+    @Override public String toString() {
+      return "DistInfo(" + tags + ", " + count + ", " + totalAmount + ")";
+    }
   }
 
   public static class GaugeInfo {
@@ -200,9 +260,30 @@ public class SpectatorEndpoint implements HttpEndpoint {
     public double getValue() {
       return value;
     }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      GaugeInfo gaugeInfo = (GaugeInfo) o;
+      return Double.compare(gaugeInfo.value, value) == 0 && tags.equals(gaugeInfo.tags);
+    }
+
+    @Override public int hashCode() {
+      int result;
+      long temp;
+      result = tags.hashCode();
+      temp = Double.doubleToLongBits(value);
+      result = 31 * result + (int) (temp ^ (temp >>> 32));
+      return result;
+    }
+
+    @Override public String toString() {
+      return "GaugeInfo(" + tags + ", " + value + ")";
+    }
   }
 
-  private interface Query {
+  interface Query {
 
     Query TRUE = new Query() {
       @Override public boolean matches(Map<String, String> tags) {
@@ -371,7 +452,7 @@ public class SpectatorEndpoint implements HttpEndpoint {
     }
 
     @Override public String toString() {
-      return q1 + "," + q2 + ",:pr";
+      return q1 + "," + q2 + ",:or";
     }
   }
 

--- a/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SpectatorEndpointTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SpectatorEndpointTest.java
@@ -43,177 +43,185 @@ public class SpectatorEndpointTest {
     registry.gauge("gauge1", 100.0);
   }
 
+  @SuppressWarnings("unchecked")
+  private <T> List<T> get(String q) {
+    List<T> d1 = (List<T>) endpoint.get(q);
+
+    // Verify that toString on parsed query yields the same result
+    SpectatorEndpoint.Query query = SpectatorEndpoint.Query.parse(q);
+    List<T> d2 = (List<T>) endpoint.get(query.toString());
+
+    Assert.assertEquals(d1, d2);
+    return d1;
+  }
+
   @Test @SuppressWarnings("unchecked")
   public void get() {
     List<Object> datapoints = (List<Object>) endpoint.get();
     Assert.assertEquals(registry.stream().count(), datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getTrue() {
-    List<Object> datapoints = (List<Object>) endpoint.get(":true");
-    Assert.assertEquals(registry.stream().count(), datapoints.size());
+    Assert.assertEquals(registry.stream().count(), get(":true").size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getFalse() {
-    List<Object> datapoints = (List<Object>) endpoint.get(":false");
-    Assert.assertEquals(0, datapoints.size());
+    Assert.assertEquals(0, get(":false").size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getHasName() {
-    List<Object> datapoints = (List<Object>) endpoint.get("name,:has");
+    List<Object> datapoints = get("name,:has");
     Assert.assertEquals(registry.stream().count(), datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getHasB() {
-    List<Object> datapoints = (List<Object>) endpoint.get("b,:has");
+    List<Object> datapoints = get("b,:has");
     Assert.assertEquals(1, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getEqual() {
-    List<Object> datapoints = (List<Object>) endpoint.get("name,counter1,:eq");
+    List<Object> datapoints = get("name,counter1,:eq");
     Assert.assertEquals(1, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getEqualA() {
-    List<Object> datapoints = (List<Object>) endpoint.get("a,1,:eq");
+    List<Object> datapoints = get("a,1,:eq");
     Assert.assertEquals(3, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getLessThan() {
-    List<Object> datapoints = (List<Object>) endpoint.get("name,distSummary1,:lt");
+    List<Object> datapoints = get("name,distSummary1,:lt");
     Assert.assertEquals(2, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getLessThanEqual() {
-    List<Object> datapoints = (List<Object>) endpoint.get("name,distSummary1,:le");
+    List<Object> datapoints = get("name,distSummary1,:le");
     Assert.assertEquals(3, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getGreaterThan() {
-    List<Object> datapoints = (List<Object>) endpoint.get("name,gauge1,:gt");
+    List<Object> datapoints = get("name,gauge1,:gt");
     Assert.assertEquals(1, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getGreaterThanEqual() {
-    List<Object> datapoints = (List<Object>) endpoint.get("name,gauge1,:ge");
+    List<Object> datapoints = get("name,gauge1,:ge");
     Assert.assertEquals(2, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getIn1() {
-    List<Object> datapoints = (List<Object>) endpoint.get("name,(,gauge1,),:in");
+    List<Object> datapoints = get("name,(,gauge1,),:in");
     Assert.assertEquals(1, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getIn2() {
-    List<Object> datapoints = (List<Object>) endpoint.get("name,(,counter1,gauge1,),:in");
+    List<Object> datapoints = get("name,(,counter1,gauge1,),:in");
     Assert.assertEquals(2, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getInEmpty() {
-    List<Object> datapoints = (List<Object>) endpoint.get("name,(,),:in");
+    List<Object> datapoints = get("name,(,),:in");
     Assert.assertEquals(0, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getInNoMatchingKey() {
-    List<Object> datapoints = (List<Object>) endpoint.get("z,(,foo,),:in");
+    List<Object> datapoints = get("z,(,foo,),:in");
     Assert.assertEquals(0, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getCounters() {
-    List<SpectatorEndpoint.CounterInfo> datapoints =
-        (List<SpectatorEndpoint.CounterInfo>) endpoint.get("name,counter,:re");
+    List<SpectatorEndpoint.CounterInfo> datapoints = get("name,counter,:re");
     Assert.assertEquals(2, datapoints.size());
-    datapoints.stream().forEach(c -> Assert.assertEquals("counter", c.getType()));
+    datapoints.forEach(c -> Assert.assertEquals("counter", c.getType()));
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getCounter1() {
-    List<SpectatorEndpoint.CounterInfo> datapoints =
-        (List<SpectatorEndpoint.CounterInfo>) endpoint.get("name,counter,:re,a,1,:eq,:and");
+    List<SpectatorEndpoint.CounterInfo> datapoints = get("name,counter,:re,a,1,:eq,:and");
     Assert.assertEquals(1, datapoints.size());
     Assert.assertEquals(3, datapoints.get(0).getTags().size());
     Assert.assertEquals(1, datapoints.get(0).getCount());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getCounter2() {
-    List<SpectatorEndpoint.CounterInfo> datapoints =
-        (List<SpectatorEndpoint.CounterInfo>) endpoint.get("name,counter,:re,a,2,:eq,:and");
+    List<SpectatorEndpoint.CounterInfo> datapoints = get("name,counter,:re,a,2,:eq,:and");
     Assert.assertEquals(1, datapoints.size());
     Assert.assertEquals(3, datapoints.get(0).getTags().size());
     Assert.assertEquals(42, datapoints.get(0).getCount());
   }
 
-  @Test @SuppressWarnings("unchecked")
-  public void getTimers() {
-    List<SpectatorEndpoint.TimerInfo> datapoints =
-        (List<SpectatorEndpoint.TimerInfo>) endpoint.get("name,timer,:re");
-    Assert.assertEquals(1, datapoints.size());
-    datapoints.stream().forEach(c -> Assert.assertEquals("timer", c.getType()));
+  @Test
+  public void getCounter1Or2() {
+    List<SpectatorEndpoint.CounterInfo> datapoints = get("name,counter,:re,a,1,:eq,a,2,:eq,:or,:and");
+    Assert.assertEquals(2, datapoints.size());
+    Assert.assertEquals(3, datapoints.get(0).getTags().size());
+    Assert.assertEquals(42, datapoints.get(0).getCount());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
+  public void getTimers() {
+    List<SpectatorEndpoint.TimerInfo> datapoints = get("name,timer,:re");
+    Assert.assertEquals(1, datapoints.size());
+    datapoints.forEach(c -> Assert.assertEquals("timer", c.getType()));
+  }
+
+  @Test
   public void getTimer1() {
-    List<SpectatorEndpoint.TimerInfo> datapoints =
-        (List<SpectatorEndpoint.TimerInfo>) endpoint.get("name,timer1,:eq");
+    List<SpectatorEndpoint.TimerInfo> datapoints = get("name,timer1,:eq");
     Assert.assertEquals(1, datapoints.size());
     Assert.assertEquals(2, datapoints.get(0).getTags().size());
     Assert.assertEquals(1L, datapoints.get(0).getCount());
     Assert.assertEquals(42000000000L, datapoints.get(0).getTotalTime());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getDistSummaries() {
-    List<SpectatorEndpoint.DistInfo> datapoints =
-        (List<SpectatorEndpoint.DistInfo>) endpoint.get("name,distSummary,:re");
+    List<SpectatorEndpoint.DistInfo> datapoints = get("name,distSummary,:re");
     Assert.assertEquals(1, datapoints.size());
-    datapoints.stream().forEach(c -> Assert.assertEquals("distribution-summary", c.getType()));
+    datapoints.forEach(c -> Assert.assertEquals("distribution-summary", c.getType()));
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getDistSummariesEmptyRE() {
-    List<SpectatorEndpoint.DistInfo> datapoints =
-        (List<SpectatorEndpoint.DistInfo>) endpoint.get("name,distsummary,:re");
+    List<SpectatorEndpoint.DistInfo> datapoints = get("name,distsummary,:re");
     Assert.assertEquals(0, datapoints.size());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getDistSummariesREIC() {
-    List<SpectatorEndpoint.DistInfo> datapoints =
-        (List<SpectatorEndpoint.DistInfo>) endpoint.get("name,distsummary,:reic");
+    List<SpectatorEndpoint.DistInfo> datapoints = get("name,distsummary,:reic");
     Assert.assertEquals(1, datapoints.size());
-    datapoints.stream().forEach(c -> Assert.assertEquals("distribution-summary", c.getType()));
+    datapoints.forEach(c -> Assert.assertEquals("distribution-summary", c.getType()));
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getDist1() {
-    List<SpectatorEndpoint.DistInfo> datapoints =
-        (List<SpectatorEndpoint.DistInfo>) endpoint.get("name,distSummary1,:eq");
+    List<SpectatorEndpoint.DistInfo> datapoints = get("name,distSummary1,:eq");
     Assert.assertEquals(1, datapoints.size());
     Assert.assertEquals(2, datapoints.get(0).getTags().size());
     Assert.assertEquals(1L, datapoints.get(0).getCount());
     Assert.assertEquals(47L, datapoints.get(0).getTotalAmount());
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void getGauge1() {
-    List<SpectatorEndpoint.GaugeInfo> datapoints =
-        (List<SpectatorEndpoint.GaugeInfo>) endpoint.get("name,gauge1,:eq");
+    List<SpectatorEndpoint.GaugeInfo> datapoints = get("name,gauge1,:eq");
     Assert.assertEquals(1, datapoints.size());
     Assert.assertEquals(1, datapoints.get(0).getTags().size());
     Assert.assertEquals(100.0, datapoints.get(0).getValue(), 1e-12);


### PR DESCRIPTION
Fixes the toString representation of the OrQuery. It was
returning `:pr` instead of `:or`. Updates the test cases
to verify we get the same result from the toString output
of the query.