### PR TITLE
fix #275, add binding for eureka optional args

### DIFF
--- a/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
+++ b/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
@@ -27,9 +27,11 @@ import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.config.ConfigurationManager;
+import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
 import com.netflix.discovery.DefaultEurekaClientConfig;
 import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.EurekaClientConfig;
+import com.netflix.discovery.shared.transport.jersey.Jersey1DiscoveryClientOptionalArgs;
 import com.netflix.iep.admin.AdminModule;
 import com.netflix.iep.admin.AdminServer;
 import com.netflix.iep.service.Service;
@@ -66,7 +68,10 @@ public final class EurekaModule extends AbstractModule {
     // EurekaClientConfig
     bind(EurekaClientConfig.class).to(DefaultEurekaClientConfig.class).asEagerSingleton();
 
-    // DiscoveryClientOptionalArgs, automatic via field injection
+    // DiscoveryClientOptionalArgs, as of 1.6.0 we need to have an explicit binding. Using
+    // Jersey1 as it is recommended by runtime team.
+    bind(AbstractDiscoveryClientOptionalArgs.class)
+        .to(Jersey1DiscoveryClientOptionalArgs.class).asEagerSingleton();
 
     // BackupRegistry, automatic via ImplementedBy annotation
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object Versions {
     val archaius   = "2.1.9"
     val aws        = "1.11.41"
-    val eureka     = "1.5.6"
+    val eureka     = "1.6.0"
     val guice      = "4.1.0"
     val jackson    = "2.8.3"
     val rxnetty    = "0.4.19"


### PR DESCRIPTION
As of 1.6.0 an explicit binding is needed. Using the Jersey1
binding as that is the currently recommended and most tested
use. There is also a Jersey2 impl in 1.6.0.