### PR TITLE
move user service to common lib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ lazy val root = project.in(file("."))
     `iep-module-eureka`,
     `iep-module-jmxport`,
     `iep-module-rxnetty`,
+    `iep-module-userservice`,
     `iep-nflxenv`,
     `iep-platformservice`,
     `iep-rxhttp`,
@@ -153,6 +154,19 @@ lazy val `iep-module-rxnetty` = project
     Dependencies.rxnettyCore,
     Dependencies.rxnettyCtxts,
     Dependencies.slf4jApi
+  ))
+
+lazy val `iep-module-userservice` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`iep-service`)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.guiceCore,
+    Dependencies.guiceMulti,
+    Dependencies.jacksonMapper,
+    Dependencies.slf4jApi,
+    Dependencies.spectatorApi,
+    Dependencies.spectatorSandbox,
+    Dependencies.typesafeConfig
   ))
 
 lazy val `iep-nflxenv` = project

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/AbstractUserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/AbstractUserService.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.netflix.iep.service.AbstractService;
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Functions;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.sandbox.HttpResponse;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Base class for user services that fetch a JSON payload from an HTTP endpoint.
+ */
+abstract class AbstractUserService extends AbstractService implements UserService {
+
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private final String name = getClass().getSimpleName();
+
+  protected final Context context;
+  protected final String uri;
+  protected final boolean enabled;
+
+  private final AtomicLong lastUpdateTime;
+
+  AbstractUserService(Context context, String service) {
+    this.context = context;
+    Config config = context.config().getConfig(service);
+    this.uri = config.getString("uri");
+    this.enabled = config.getBoolean("enabled");
+
+    Registry registry = context.registry();
+    Clock clock = registry.clock();
+    Id cacheAge = registry.createId("iep.users.cacheAge", "id", name);
+    lastUpdateTime = enabled
+        ? registry.gauge(cacheAge, new AtomicLong(clock.wallTime()), Functions.age(clock))
+        : new AtomicLong(0L);
+  }
+
+  protected abstract void handleResponse(byte[] data) throws IOException;
+
+  @Override
+  protected void startImpl() throws Exception {
+    if (enabled) {
+      // Block until we are able to get list at least once
+      while (!refresh()) {
+        Thread.sleep(context.frequency());
+      }
+
+      // Startup background task to regularly refresh
+      context.executor().scheduleWithFixedDelay(this::refresh,
+          0L, context.frequency(), TimeUnit.MILLISECONDS);
+    } else {
+      logger.debug("service not enabled");
+    }
+  }
+
+  @Override
+  protected void stopImpl() throws Exception {
+  }
+
+  private boolean refresh() {
+    try {
+      refreshData();
+      lastUpdateTime.set(context.registry().clock().wallTime());
+      return true;
+    } catch (Exception e) {
+      e.printStackTrace();
+      logger.warn("failed to refresh users list", e);
+      return false;
+    }
+  }
+
+  private void refreshData() throws IOException {
+    HttpResponse res = context.get(name, uri);
+    if (res.status() == 200) {
+      handleResponse(res.entity());
+    } else {
+      throw new IOException("request to " + uri + " failed with status " + res.status());
+    }
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/CompositeUserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/CompositeUserService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.netflix.iep.service.AbstractService;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Combines a set of other user services into a combined view. It is assumed
+ * that there is no overlap in the data sets.
+ */
+@Singleton
+class CompositeUserService extends AbstractService implements UserService {
+
+  private final Set<UserService> services;
+
+  @Inject
+  CompositeUserService(Set<UserService> services) {
+    this.services = services;
+  }
+
+  @Override protected void startImpl() throws Exception {
+  }
+
+  @Override protected void stopImpl() throws Exception {
+  }
+
+  @Override public Set<String> emailAddresses() {
+    Set<String> vs = new TreeSet<>();
+    for (UserService service : services) {
+      vs.addAll(service.emailAddresses());
+    }
+    return Collections.unmodifiableSet(vs);
+  }
+
+  @Override public boolean isValidEmail(String email) {
+    return services.stream().anyMatch(s -> s.isValidEmail(email));
+  }
+
+  @Override public String toValidEmail(String email) {
+    for (UserService service : services) {
+      String v = service.toValidEmail(email);
+      if (v != null) {
+        return v;
+      }
+    }
+    return null;
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/Context.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/Context.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.sandbox.HttpClient;
+import com.netflix.spectator.sandbox.HttpResponse;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/** Common settings used across all services. */
+@Singleton
+public final class Context {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  private final Registry registry;
+
+  private final Config config;
+  private final HttpClient client;
+
+  private final int connectTimeout;
+  private final int readTimeout;
+
+  private final int frequency;
+
+  private final ScheduledExecutorService executor;
+
+  @Inject
+  public Context(Registry registry, Config config, HttpClient client) {
+    this.registry = registry;
+    this.config = config.getConfig("netflix.iep.userservice");
+    this.client = client;
+
+    connectTimeout = (int) this.config.getDuration("connect-timeout", TimeUnit.MILLISECONDS);
+    readTimeout = (int) this.config.getDuration("read-timeout", TimeUnit.MILLISECONDS);
+
+    frequency = (int) this.config.getDuration("frequency", TimeUnit.MILLISECONDS);
+
+    executor = Executors.newSingleThreadScheduledExecutor(r -> {
+      Thread t = new Thread(r, "iep-userservice");
+      t.setDaemon(true);
+      return t;
+    });
+  }
+
+  @PreDestroy
+  public void stop() {
+    executor.shutdown();
+  }
+
+  ObjectMapper objectMapper() {
+    return mapper;
+  }
+
+  Registry registry() {
+    return registry;
+  }
+
+  Config config() {
+    return config;
+  }
+
+  HttpResponse get(String name, String uri) throws IOException {
+    return client.newRequest(name, URI.create(uri))
+        .withMethod("GET")
+        .withConnectTimeout(connectTimeout)
+        .withReadTimeout(readTimeout)
+        .withRetries(2)
+        .acceptJson()
+        .acceptGzip()
+        .send()
+        .decompress();
+  }
+
+  int frequency() {
+    return frequency;
+  }
+
+  ScheduledExecutorService executor() {
+    return executor;
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/DepartedUserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/DepartedUserService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Collects mappings from whitepages departed endpoint. The valid email addresses
+ * returned are the values associated with the mapping.
+ */
+@Singleton
+final class DepartedUserService extends AbstractUserService {
+
+  private static final TypeReference<Map<String, String>> MAP_TYPE =
+      new TypeReference<Map<String, String>>() {};
+
+  private final AtomicReference<Set<String>> emails =
+      new AtomicReference<>(Collections.emptySet());
+
+  private final AtomicReference<Map<String, String>> mapping =
+      new AtomicReference<>(Collections.emptyMap());
+
+  @Inject
+  DepartedUserService(Context context) {
+    super(context, "departed");
+  }
+
+  @Override public Set<String> emailAddresses() {
+    return emails.get();
+  }
+
+  @Override protected void handleResponse(byte[] data) throws IOException {
+    Map<String, String> vs = context.objectMapper().readValue(data, MAP_TYPE);
+    emails.set(Collections.unmodifiableSet(new TreeSet<>(vs.values())));
+    mapping.set(vs);
+  }
+
+  @Override public String toValidEmail(String email) {
+    return isValidEmail(email)
+        ? email
+        : mapping.get().get(UserUtils.baseAddress(email));
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/EmployeeUserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/EmployeeUserService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * Collects emails from whitepages employee endpoint.
+ */
+@Singleton
+final class EmployeeUserService extends AbstractUserService {
+
+  private static final TypeReference<List<User>> LIST_TYPE = new TypeReference<List<User>>() {};
+
+  private final AtomicReference<Set<String>> emails = new AtomicReference<>(Collections.emptySet());
+
+  @Inject
+  EmployeeUserService(Context context) {
+    super(context, "employee");
+  }
+
+  @Override public Set<String> emailAddresses() {
+    return emails.get();
+  }
+
+  @Override protected void handleResponse(byte[] data) throws IOException {
+    List<User> vs = context.objectMapper().readValue(data, LIST_TYPE);
+    Set<String> es = vs.stream()
+        .filter(User::isValid)
+        .map(User::getEmail)
+        .collect(Collectors.toSet());
+    emails.set(Collections.unmodifiableSet(new TreeSet<>(es)));
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class User {
+    private String email;
+    private String termDate;
+
+    User() {
+    }
+
+    public void setEmail(String email) {
+      this.email = email;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    @JsonSetter("term_date")
+    public void setTermDate(String date) {
+      this.termDate = date;
+    }
+
+    public boolean isValid() {
+      return email != null && termDate == null;
+    }
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/SimpleUserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/SimpleUserService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Service based on an enpdoint that returns a simple JSON list of emails. For
+ * example the whitepages mailing list endpoint.
+ */
+@Singleton
+final class SimpleUserService extends AbstractUserService {
+
+  private static final TypeReference<Set<String>> SET_TYPE = new TypeReference<Set<String>>() {};
+
+  private final AtomicReference<Set<String>> emails = new AtomicReference<>(Collections.emptySet());
+
+  @Inject
+  SimpleUserService(Context context) {
+    super(context, "simple");
+  }
+
+  @Override public Set<String> emailAddresses() {
+    return emails.get();
+  }
+
+  @Override protected void handleResponse(byte[] data) throws IOException {
+    Set<String> vs = context.objectMapper().readValue(data, SET_TYPE);
+    emails.set(Collections.unmodifiableSet(new TreeSet<>(vs)));
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/UserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/UserService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import java.util.Set;
+
+/**
+ * Service for tracking the set of valid users (email addresses) available in the
+ * environment. This is typically used for validation in use-cases where we should
+ * only have known good addresses.
+ */
+public interface UserService {
+
+  /** Returns the set of all email addresses. */
+  Set<String> emailAddresses();
+
+  /**
+   * Checks to see if an email address is valid for this service.
+   *
+   * @param email
+   *     The email address to check. This may not be an exact match for an address
+   *     in the set returned by {@link #emailAddresses()}. In particular,
+   *     <a href="https://tools.ietf.org/html/rfc5233#section-4">subaddresses</a>
+   *     will not be in the set, but will be indicated as valid.
+   * @return
+   *     True if the email is valid based on the set of available addresses for this
+   *     service.
+   */
+  default boolean isValidEmail(String email) {
+    return emailAddresses().contains(UserUtils.baseAddress(email));
+  }
+
+  /**
+   * Attempts to convert a given email address to a valid address for this service. By
+   * default it will simply check if the provided email is valid and return it without
+   * modification. Some implementations may also support replacing old mailing lists or
+   * departed users with replacements.
+   *
+   * @param email
+   *     The email address to convert.
+   * @return
+   *     Valid email or null if none could be found.
+   */
+  default String toValidEmail(String email) {
+    return isValidEmail(email) ? email : null;
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/UserServiceModule.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/UserServiceModule.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.multibindings.Multibinder;
+import com.netflix.iep.service.Service;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.sandbox.HttpClient;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+/**
+ * Setup bindings for {@link UserService}.
+ */
+public class UserServiceModule extends AbstractModule {
+  @Override protected void configure() {
+    bind(Context.class).toProvider(ContextProvider.class);
+    bind(UserService.class).to(CompositeUserService.class);
+
+    Multibinder<UserService> userBinder = Multibinder.newSetBinder(binder(), UserService.class);
+    userBinder.addBinding().to(DepartedUserService.class);
+    userBinder.addBinding().to(EmployeeUserService.class);
+    userBinder.addBinding().to(SimpleUserService.class);
+    userBinder.addBinding().to(WhitelistUserService.class);
+
+    Multibinder<Service> serviceBinder = Multibinder.newSetBinder(binder(), Service.class);
+    serviceBinder.addBinding().to(DepartedUserService.class);
+    serviceBinder.addBinding().to(EmployeeUserService.class);
+    serviceBinder.addBinding().to(SimpleUserService.class);
+    serviceBinder.addBinding().to(WhitelistUserService.class);
+    serviceBinder.addBinding().to(CompositeUserService.class);
+  }
+
+  private static Config defaultConfig() {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    if (cl == null) {
+      cl = UserServiceModule.class.getClassLoader();
+    }
+    return ConfigFactory.load(cl);
+  }
+
+  @Singleton
+  private static class ContextProvider implements Provider<Context> {
+
+    @Inject(optional = true)
+    private Registry registry = new NoopRegistry();
+
+    @Inject(optional = true)
+    private Config config = defaultConfig();
+
+    @Inject(optional = true)
+    private HttpClient client = HttpClient.DEFAULT;
+
+    @Override public Context get() {
+      return new Context(registry, config, client);
+    }
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/UserUtils.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/UserUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helper functions for working with users.
+ */
+final class UserUtils {
+  private UserUtils() {
+  }
+
+  private static final Pattern SUB_ADDRESS = Pattern.compile("^([^+]+)\\+[^@]+(@.*)$");
+
+  /**
+   * Return the base address without the detail portion. For example
+   * {@code foo+bar@example.com} would return {@code foo@example.com}.
+   */
+  static String baseAddress(String email) {
+    Matcher m = SUB_ADDRESS.matcher(email);
+    return m.matches() ? m.group(1) + m.group(2) : email;
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/WhitelistUserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/WhitelistUserService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.netflix.iep.service.AbstractService;
+import com.typesafe.config.Config;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Service based on an explicit list if addresses and mappings provided in the
+ * config.
+ */
+@Singleton
+class WhitelistUserService extends AbstractService implements UserService {
+
+  private final Set<String> emails;
+  private final Map<String, String> mappings;
+
+  @Inject
+  WhitelistUserService(Context context) {
+    Config config = context.config().getConfig("whitelist");
+    emails = Collections.unmodifiableSet(new TreeSet<>(config.getStringList("emails")));
+    mappings = new HashMap<>();
+    for (Config c : config.getConfigList("mappings")) {
+      mappings.put(c.getString("email"), c.getString("replacement"));
+    }
+  }
+
+  @Override protected void startImpl() throws Exception {
+  }
+
+  @Override protected void stopImpl() throws Exception {
+  }
+
+  @Override public Set<String> emailAddresses() {
+    return emails;
+  }
+
+  @Override public String toValidEmail(String email) {
+    return isValidEmail(email)
+        ? email
+        : mappings.get(UserUtils.baseAddress(email));
+  }
+}

--- a/iep-module-userservice/src/main/resources/META-INF/services/org.google.inject.Module
+++ b/iep-module-userservice/src/main/resources/META-INF/services/org.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.iep.userservice.UserServiceModule

--- a/iep-module-userservice/src/main/resources/reference.conf
+++ b/iep-module-userservice/src/main/resources/reference.conf
@@ -1,0 +1,34 @@
+
+netflix.iep.userservice {
+  connect-timeout = 1s
+  read-timeout = 30s
+  frequency = 5m
+
+  simple {
+    enabled = false
+    uri = ""
+  }
+
+  employee {
+    enabled = false
+    uri = ""
+  }
+
+  departed {
+    enabled = false
+    uri = ""
+  }
+
+  whitelist {
+    emails = [
+      //"foo@example.com"
+    ]
+
+    mappings = [
+      //{
+      //  email = "old-list@example.com"
+      //  replacement = "new-list@example.com"
+      //}
+    ]
+  }
+}

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/CompositeUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/CompositeUserServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@RunWith(JUnit4.class)
+public class CompositeUserServiceTest {
+
+  @Test
+  public void emptySet() {
+    UserService service = new CompositeUserService(Collections.emptySet());
+    Assert.assertEquals(0, service.emailAddresses().size());
+    Assert.assertFalse(service.isValidEmail("foo@example.com"));
+    Assert.assertNull(service.toValidEmail("foo@example.com"));
+  }
+
+  @Test
+  public void singletonSet() {
+    UserService service = new CompositeUserService(
+        Collections.singleton(() -> Collections.singleton("foo@example.com")));
+    Assert.assertEquals(1, service.emailAddresses().size());
+    Assert.assertTrue(service.isValidEmail("foo@example.com"));
+    Assert.assertFalse(service.isValidEmail("bar@example.com"));
+    Assert.assertEquals("foo@example.com", service.toValidEmail("foo@example.com"));
+  }
+
+  @Test
+  public void multiSet() {
+    Set<UserService> services = new HashSet<>();
+    services.add(() -> Collections.singleton("foo@example.com"));
+    services.add(() -> Collections.singleton("bar@example.com"));
+    services.add(() -> Collections.singleton("baz@example.com"));
+    UserService service = new CompositeUserService(services);
+    Assert.assertEquals(3, service.emailAddresses().size());
+    Assert.assertTrue(service.isValidEmail("foo@example.com"));
+    Assert.assertTrue(service.isValidEmail("bar@example.com"));
+    Assert.assertFalse(service.isValidEmail("abc@example.com"));
+    Assert.assertEquals("foo@example.com", service.toValidEmail("foo@example.com"));
+    Assert.assertEquals("bar@example.com", service.toValidEmail("bar@example.com"));
+    Assert.assertNull(service.toValidEmail("abc@example.com"));
+  }
+}

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/DepartedUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/DepartedUserServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.sandbox.HttpClient;
+import com.netflix.spectator.sandbox.HttpResponse;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+@RunWith(JUnit4.class)
+public class DepartedUserServiceTest {
+
+  private ManualClock clock = new ManualClock();
+  private Registry registry = new DefaultRegistry(clock);
+  private Config config = ConfigFactory.load();
+
+  private Context newContext(HttpClient client) {
+    return new Context(registry, config, client);
+  }
+
+  private HttpResponse ok(String data) {
+    return new HttpResponse(200, Collections.emptyMap(), data.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void start() throws Exception {
+    Context ctxt = newContext(new TestClient(() -> ok("{\"bar@example.com\":\"foo@example.com\"}")));
+    DepartedUserService service = new DepartedUserService(ctxt);
+    Assert.assertEquals(0, service.emailAddresses().size());
+
+    service.start();
+    Assert.assertEquals(1, service.emailAddresses().size());
+    Assert.assertTrue(service.isValidEmail("foo@example.com"));
+    Assert.assertFalse(service.isValidEmail("bar@example.com"));
+    Assert.assertEquals("foo@example.com", service.toValidEmail("bar@example.com"));
+    Assert.assertEquals("foo@example.com", service.toValidEmail("bar+alert@example.com"));
+
+    service.stop();
+  }
+}

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/EmployeeUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/EmployeeUserServiceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.sandbox.HttpClient;
+import com.netflix.spectator.sandbox.HttpResponse;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+@RunWith(JUnit4.class)
+public class EmployeeUserServiceTest {
+
+  private ManualClock clock = new ManualClock();
+  private Registry registry = new DefaultRegistry(clock);
+  private Config config = ConfigFactory.load();
+
+  private Context newContext(HttpClient client) {
+    return new Context(registry, config, client);
+  }
+
+  private HttpResponse ok(String data) {
+    return new HttpResponse(200, Collections.emptyMap(), data.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private void test(String payload) throws Exception {
+    Context ctxt = newContext(new TestClient(() -> ok(payload)));
+    EmployeeUserService service = new EmployeeUserService(ctxt);
+    Assert.assertEquals(0, service.emailAddresses().size());
+
+    service.start();
+    Assert.assertEquals(1, service.emailAddresses().size());
+    Assert.assertTrue(service.isValidEmail("foo@example.com"));
+    Assert.assertFalse(service.isValidEmail("bar@example.com"));
+
+    service.stop();
+  }
+
+  @Test
+  public void simple() throws Exception {
+    test("[{\"email\":\"foo@example.com\"}]");
+  }
+
+  @Test
+  public void unknownProp() throws Exception {
+    test("[{\"email\":\"foo@example.com\",\"foo\":1}]");
+  }
+
+  @Test
+  public void termDate() throws Exception {
+    test("[{\"email\":\"foo@example.com\"},{\"email\":\"bar@example.com\",\"term_date\":\"1234-12-01\"}]");
+  }
+}

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/SimpleUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/SimpleUserServiceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.sandbox.HttpClient;
+import com.netflix.spectator.sandbox.HttpResponse;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+@RunWith(JUnit4.class)
+public class SimpleUserServiceTest {
+
+  private ManualClock clock = new ManualClock();
+  private Registry registry = new DefaultRegistry(clock);
+  private Config config = ConfigFactory.load();
+
+  private Context newContext(HttpClient client) {
+    return new Context(registry, config, client);
+  }
+
+  private HttpResponse ok(String data) {
+    return new HttpResponse(200, Collections.emptyMap(), data.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void start() throws Exception {
+    Context ctxt = newContext(new TestClient(() -> ok("[\"foo@example.com\"]")));
+    SimpleUserService service = new SimpleUserService(ctxt);
+    Assert.assertEquals(0, service.emailAddresses().size());
+
+    service.start();
+    Assert.assertEquals(1, service.emailAddresses().size());
+    Assert.assertTrue(service.isValidEmail("foo@example.com"));
+    Assert.assertFalse(service.isValidEmail("bar@example.com"));
+
+    service.stop();
+  }
+}

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/TestClient.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/TestClient.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.netflix.spectator.sandbox.HttpClient;
+import com.netflix.spectator.sandbox.HttpRequestBuilder;
+import com.netflix.spectator.sandbox.HttpResponse;
+
+import java.io.IOException;
+import java.net.URI;
+
+class TestClient implements HttpClient {
+
+  private final ResponseSupplier supplier;
+
+  TestClient(ResponseSupplier supplier) {
+    this.supplier = supplier;
+  }
+
+  @Override public HttpRequestBuilder newRequest(String clientName, URI uri) {
+    return new HttpRequestBuilder(clientName, uri) {
+      @Override protected HttpResponse sendImpl() throws IOException {
+        return supplier.get();
+      }
+    };
+  }
+
+  interface ResponseSupplier {
+    HttpResponse get() throws IOException;
+  }
+}

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/UserServiceModuleTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/UserServiceModuleTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.iep.service.Service;
+import com.netflix.iep.service.ServiceManager;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+@RunWith(JUnit4.class)
+public class UserServiceModuleTest {
+
+  @Test
+  public void services() throws Exception {
+    Injector injector = Guice.createInjector(new UserServiceModule());
+
+    ServiceManager manager = injector.getInstance(ServiceManager.class);
+    Assert.assertNotNull(manager);
+
+    Set<String> expected = new TreeSet<>();
+    expected.add("DepartedUserService");
+    expected.add("EmployeeUserService");
+    expected.add("SimpleUserService");
+    expected.add("WhitelistUserService");
+    expected.add("CompositeUserService");
+    Set<String> result = manager.services().stream()
+        .map(Service::name)
+        .collect(Collectors.toSet());
+    Assert.assertEquals(expected, result);
+  }
+
+  @Test
+  public void userService() throws Exception {
+    Injector injector = Guice.createInjector(new UserServiceModule());
+    UserService s = injector.getInstance(UserService.class);
+    Assert.assertNotNull(s);
+    Assert.assertTrue(s instanceof CompositeUserService);
+  }
+
+  @Test
+  public void specificUserService() throws Exception {
+    Injector injector = Guice.createInjector(new UserServiceModule());
+    SimpleUserService s = injector.getInstance(SimpleUserService.class);
+    Assert.assertNotNull(s);
+  }
+}

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/UserUtilsTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/UserUtilsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class UserUtilsTest {
+
+  @Test
+  public void baseEmailNoChange() throws Exception {
+    Assert.assertEquals("foo@example.com", UserUtils.baseAddress("foo@example.com"));
+  }
+
+  @Test
+  public void baseEmailWithSubAddress() throws Exception {
+    Assert.assertEquals("foo@example.com", UserUtils.baseAddress("foo+bar-baz@example.com"));
+  }
+}

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/WhitelistUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/WhitelistUserServiceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.sandbox.HttpClient;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class WhitelistUserServiceTest {
+
+  private ManualClock clock = new ManualClock();
+  private Registry registry = new DefaultRegistry(clock);
+  private Config config = ConfigFactory.load();
+  private Context context = new Context(registry, config, HttpClient.DEFAULT);
+
+  @Test
+  public void start() throws Exception {
+    WhitelistUserService service = new WhitelistUserService(context);
+    Assert.assertEquals(2, service.emailAddresses().size());
+
+    Assert.assertTrue(service.isValidEmail("foo@example.com"));
+    Assert.assertTrue(service.isValidEmail("foo+alert@example.com"));
+    Assert.assertTrue(service.isValidEmail("bar@example.com"));
+    Assert.assertFalse(service.isValidEmail("baz@example.com"));
+
+    Assert.assertEquals("foo@example.com", service.toValidEmail("foo@example.com"));
+    Assert.assertEquals("foo+alert@example.com", service.toValidEmail("foo+alert@example.com"));
+    Assert.assertEquals("foo@example.com", service.toValidEmail("abc@example.com"));
+    Assert.assertEquals("foo@example.com", service.toValidEmail("abc+alert@example.com"));
+    Assert.assertEquals("bar@example.com", service.toValidEmail("def@example.com"));
+    Assert.assertNull(service.toValidEmail("ghi@example.com"));
+  }
+}

--- a/iep-module-userservice/src/test/resources/application.conf
+++ b/iep-module-userservice/src/test/resources/application.conf
@@ -1,0 +1,32 @@
+
+netflix.iep.userservice {
+  simple {
+    enabled = true
+  }
+
+  employee {
+    enabled = true
+  }
+
+  departed {
+    enabled = true
+  }
+
+  whitelist {
+    emails = [
+      "foo@example.com",
+      "bar@example.com"
+    ]
+
+    mappings = [
+      {
+        email = "abc@example.com"
+        replacement = "foo@example.com"
+      },
+      {
+        email = "def@example.com"
+        replacement = "bar@example.com"
+      }
+    ]
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val rxnetty    = "0.4.19"
     val scala      = "2.11.8"
     val slf4j      = "1.7.21"
-    val spectator  = "0.42.0"
+    val spectator  = "0.43.0"
   }
 
   import Versions._


### PR DESCRIPTION
A number of internal apps have the same basic service
for looking up the set of users (email addresses) that
are valid for a given context.