### PR TITLE
switch to using builder for AWS clients

### DIFF
--- a/iep-module-aws/src/main/resources/reference.conf
+++ b/iep-module-aws/src/main/resources/reference.conf
@@ -39,7 +39,8 @@ netflix.iep.aws {
       // Sometimes useful to customize for logging, but the default value is typically good enough.
       // Sample of default:
       // aws-sdk-java/1.8.9.1 Linux/3.2.0-54-virtual Java_HotSpot(TM)_64-Bit_Server_VM/25.0-b70/1.8.0
-      //user-agent
+      //user-agent-prefix
+      //user-agent-suffix
 
       // If you need to proxy:
       //proxy-port
@@ -52,238 +53,46 @@ netflix.iep.aws {
   }
 
   // http://docs.aws.amazon.com/general/latest/gr/rande.html
+  // This is used to set overrides when a service is not available locally in the
+  // region we are running in.
   endpoint {
 
-    autoscaling {
-      us-east-1 = autoscaling.us-east-1.amazonaws.com
-      us-west-2 = autoscaling.us-west-2.amazonaws.com
-      us-west-1 = autoscaling.us-west-1.amazonaws.com
-      eu-west-1 = autoscaling.eu-west-1.amazonaws.com
-      eu-central-1 = autoscaling.eu-central-1.amazonaws.com
-      ap-southeast-1 = autoscaling.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = autoscaling.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = autoscaling.ap-northeast-1.amazonaws.com
-      sa-east-1 = autoscaling.sa-east-1.amazonaws.com
-    }
-
-    cloudformation {
-      us-east-1 = cloudformation.us-east-1.amazonaws.com
-      us-west-2 = cloudformation.us-west-2.amazonaws.com
-      us-west-1 = cloudformation.us-west-1.amazonaws.com
-      eu-west-1 = cloudformation.eu-west-1.amazonaws.com
-      eu-central-1 = cloudformation.eu-central-1.amazonaws.com
-      ap-southeast-1 = cloudformation.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = cloudformation.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = cloudformation.ap-northeast-1.amazonaws.com
-      sa-east-1 = cloudformation.sa-east-1.amazonaws.com
-    }
-
-    cloudsearch {
-      us-east-1 = cloudsearch.us-east-1.amazonaws.com
-      us-west-1 = cloudsearch.us-west-1.amazonaws.com
-      us-west-2 = cloudsearch.us-west-2.amazonaws.com
-      eu-west-1 = cloudsearch.eu-west-1.amazonaws.com
-      eu-central-1 = cloudsearch.eu-central-1.amazonaws.com
-      ap-southeast-1 = cloudsearch.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = cloudsearch.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = cloudsearch.ap-northeast-1.amazonaws.com
-      sa-east-1 = cloudsearch.sa-east-1.amazonaws.com
-    }
-
-    cloudtrail {
-      us-east-1 = cloudtrail.us-east-1.amazonaws.com
-      us-west-1 = cloudtrail.us-west-1.amazonaws.com
-      us-west-2 = cloudtrail.us-west-2.amazonaws.com
-      eu-west-1 = cloudtrail.eu-west-1.amazonaws.com
-      eu-central-1 = cloudtrail.eu-central-1.amazonaws.com
-      ap-southeast-1 = cloudtrail.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = cloudtrail.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = cloudtrail.ap-northeast-1.amazonaws.com
-      sa-east-1 = cloudtrail.sa-east-1.amazonaws.com
-    }
-
     cloudwatch {
-      us-east-1 = monitoring.us-east-1.amazonaws.com
-      us-west-2 = monitoring.us-west-2.amazonaws.com
-      us-west-1 = monitoring.us-west-1.amazonaws.com
-      eu-west-1 = monitoring.eu-west-1.amazonaws.com
-      eu-central-1 = monitoring.eu-central-1.amazonaws.com
-      ap-southeast-1 = monitoring.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = monitoring.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = monitoring.ap-northeast-1.amazonaws.com
-      sa-east-1 = monitoring.sa-east-1.amazonaws.com
-      us-nflx-1 = monitoring.us-west-1.amazonaws.com
+      us-nflx-1 = us-west-1
     }
 
     dynamodbv2 {
-      us-east-1 = dynamodb.us-east-1.amazonaws.com
-      us-west-2 = dynamodb.us-west-2.amazonaws.com
-      us-west-1 = dynamodb.us-west-1.amazonaws.com
-      eu-west-1 = dynamodb.eu-west-1.amazonaws.com
-      eu-central-1 = dynamodb.eu-central-1.amazonaws.com
-      ap-southeast-1 = dynamodb.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = dynamodb.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = dynamodb.ap-northeast-1.amazonaws.com
-      sa-east-1 = dynamodb.sa-east-1.amazonaws.com
-      us-nflx-1 = dynamodb.us-west-1.amazonaws.com
-    }
-
-    ec2 {
-      us-east-1 = ec2.us-east-1.amazonaws.com
-      us-west-2 = ec2.us-west-2.amazonaws.com
-      us-west-1 = ec2.us-west-1.amazonaws.com
-      eu-west-1 = ec2.eu-west-1.amazonaws.com
-      eu-central-1 = ec2.eu-central-1.amazonaws.com
-      ap-southeast-1 = ec2.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = ec2.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = ec2.ap-northeast-1.amazonaws.com
-      sa-east-1 = ec2.sa-east-1.amazonaws.com
-    }
-
-    elasticache {
-      us-east-1 = elasticache.us-east-1.amazonaws.com
-      us-west-2 = elasticache.us-west-2.amazonaws.com
-      us-west-1 = elasticache.us-west-1.amazonaws.com
-      eu-west-1 = elasticache.eu-west-1.amazonaws.com
-      ap-southeast-1 = elasticache.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = elasticache.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = elasticache.ap-northeast-1.amazonaws.com
-      sa-east-1 = elasticache.sa-east-1.amazonaws.com
-    }
-
-    elasticloadbalancing {
-      us-east-1 = elasticloadbalancing.us-east-1.amazonaws.com
-      us-west-2 = elasticloadbalancing.us-west-2.amazonaws.com
-      us-west-1 = elasticloadbalancing.us-west-1.amazonaws.com
-      eu-west-1 = elasticloadbalancing.eu-west-1.amazonaws.com
-      eu-central-1 = elasticloadbalancing.eu-central-1.amazonaws.com
-      ap-southeast-1 = elasticloadbalancing.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = elasticloadbalancing.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = elasticloadbalancing.ap-northeast-1.amazonaws.com
-      sa-east-1 = elasticloadbalancing.sa-east-1.amazonaws.com
-    }
-
-    elasticmapreduce {
-      us-east-1 = elasticmapreduce.us-east-1.amazonaws.com
-      us-west-2 = elasticmapreduce.us-west-2.amazonaws.com
-      us-west-1 = elasticmapreduce.us-west-1.amazonaws.com
-      eu-west-1 = elasticmapreduce.eu-west-1.amazonaws.com
-      eu-central-1 = elasticmapreduce.eu-central-1.amazonaws.com
-      ap-southeast-1 = elasticmapreduce.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = elasticmapreduce.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = elasticmapreduce.ap-northeast-1.amazonaws.com
-      sa-east-1 = elasticmapreduce.sa-east-1.amazonaws.com
-    }
-
-    kinesis {
-      us-east-1 = kinesis.us-east-1.amazonaws.com
-      us-west-2 = kinesis.us-west-2.amazonaws.com
-      us-west-1 = kinesis.us-west-1.amazonaws.com
-      eu-west-1 = kinesis.eu-west-1.amazonaws.com
-      eu-central-1 = kinesis.eu-central-1.amazonaws.com
-      ap-southeast-1 = kinesis.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = kinesis.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = kinesis.ap-northeast-1.amazonaws.com
-    }
-
-    rds {
-      us-east-1 = rds.us-east-1.amazonaws.com
-      us-west-2 = rds.us-west-2.amazonaws.com
-      us-west-1 = rds.us-west-1.amazonaws.com
-      eu-west-1 = rds.eu-west-1.amazonaws.com
-      eu-central-1 = rds.eu-central-1.amazonaws.com
-      ap-southeast-1 = rds.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = rds.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = rds.ap-northeast-1.amazonaws.com
-      sa-east-1 = rds.sa-east-1.amazonaws.com
+      us-nflx-1 = us-west-1
     }
 
     route53 {
-      us-east-1 = route53.amazonaws.com
-      us-west-2 = route53.amazonaws.com
-      us-west-1 = route53.amazonaws.com
-      eu-west-1 = route53.amazonaws.com
-      eu-central-1 = route53.amazonaws.com
-      ap-southeast-1 = route53.amazonaws.com
-      ap-southeast-2 = route53.amazonaws.com
-      ap-northeast-1 = route53.amazonaws.com
-      sa-east-1 = route53.amazonaws.com
-    }
-
-    s3 {
-      us-east-1 = s3-external-1.amazonaws.com
-      us-west-2 = s3-us-west-2.amazonaws.com
-      us-west-1 = s3-us-west-1.amazonaws.com
-      eu-west-1 = s3-eu-west-1.amazonaws.com
-      eu-central-1 = s3-eu-central-1.amazonaws.com
-      ap-southeast-1 = s3-ap-southeast-1.amazonaws.com
-      ap-southeast-2 = s3-ap-southeast-2.amazonaws.com
-      ap-northeast-1 = s3-ap-northeast-1.amazonaws.com
-      sa-east-1 = s3-sa-east-1.amazonaws.com
-      us-nflx-1 = s3-us-west-1.amazonaws.com
-    }
-
-    securitytoken {
-      us-east-1 = sts.us-east-1.amazonaws.com
-      us-west-2 = sts.us-west-2.amazonaws.com
-      us-west-1 = sts.us-west-1.amazonaws.com
-      eu-west-1 = sts.eu-west-1.amazonaws.com
-      eu-central-1 = sts.eu-central-1.amazonaws.com
-      ap-southeast-1 = sts.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = sts.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = sts.ap-northeast-1.amazonaws.com
-      sa-east-1 = sts.sa-east-1.amazonaws.com
+      us-east-1 = us-east-1
+      us-west-2 = us-east-1
+      us-west-1 = us-east-1
+      eu-west-1 = us-east-1
+      eu-central-1 = us-east-1
+      ap-southeast-1 = us-east-1
+      ap-southeast-2 = us-east-1
+      ap-northeast-1 = us-east-1
+      sa-east-1 = us-east-1
     }
 
     simpleemail {
-      us-east-1 = email.us-east-1.amazonaws.com
-      us-west-2 = email.us-west-2.amazonaws.com
-      us-west-1 = email.us-east-1.amazonaws.com
-      eu-west-1 = email.eu-west-1.amazonaws.com
-      eu-central-1 = email.eu-west-1.amazonaws.com
-      ap-southeast-1 = email.us-east-1.amazonaws.com
-      ap-southeast-2 = email.us-east-1.amazonaws.com
-      ap-northeast-1 = email.us-east-1.amazonaws.com
-      sa-east-1 = email.us-east-1.amazonaws.com
-      us-nflx-1 = s3-us-west-2.amazonaws.com
-    }
-
-    simpleworkflow {
-      us-east-1 = swf.us-east-1.amazonaws.com
-      us-west-2 = swf.us-west-2.amazonaws.com
-      us-west-1 = swf.us-west-1.amazonaws.com
-      eu-west-1 = swf.eu-west-1.amazonaws.com
-      eu-central-1 = swf.eu-central-1.amazonaws.com
-      ap-southeast-1 = swf.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = swf.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = swf.ap-northeast-1.amazonaws.com
-      sa-east-1 = swf.sa-east-1.amazonaws.com
+      us-west-1 = us-west-2
+      eu-central-1 = eu-west-1
+      ap-southeast-1 = us-west-2
+      ap-southeast-2 = us-west-2
+      ap-northeast-1 = us-west-2
+      sa-east-1 = us-east-1
+      us-nflx-1 = us-west-2
     }
 
     sns {
-      us-east-1 = sns.us-east-1.amazonaws.com
-      us-west-2 = sns.us-west-2.amazonaws.com
-      us-west-1 = sns.us-west-1.amazonaws.com
-      eu-west-1 = sns.eu-west-1.amazonaws.com
-      eu-central-1 = sns.eu-central-1.amazonaws.com
-      ap-southeast-1 = sns.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = sns.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = sns.ap-northeast-1.amazonaws.com
-      sa-east-1 = sns.sa-east-1.amazonaws.com
-      us-nflx-1 = sns.us-west-1.amazonaws.com
+      us-nflx-1 = us-west-1
     }
 
     sqs {
-      us-east-1 = sqs.us-east-1.amazonaws.com
-      us-west-2 = sqs.us-west-2.amazonaws.com
-      us-west-1 = sqs.us-west-1.amazonaws.com
-      eu-west-1 = sqs.eu-west-1.amazonaws.com
-      eu-central-1 = sqs.eu-central-1.amazonaws.com
-      ap-southeast-1 = sqs.ap-southeast-1.amazonaws.com
-      ap-southeast-2 = sqs.ap-southeast-2.amazonaws.com
-      ap-northeast-1 = sqs.ap-northeast-1.amazonaws.com
-      sa-east-1 = sqs.sa-east-1.amazonaws.com
-      us-nflx-1 = sqs.us-west-1.amazonaws.com
+      us-nflx-1 = us-west-1
     }
   }
 }

--- a/iep-module-aws/src/test/java/com/netflix/iep/aws/AwsClientFactoryTest.java
+++ b/iep-module-aws/src/test/java/com/netflix/iep/aws/AwsClientFactoryTest.java
@@ -48,7 +48,8 @@ public class AwsClientFactoryTest {
     AwsClientFactory factory = new AwsClientFactory(config);
     ClientConfiguration settings = factory.createClientConfig(null);
     Assert.assertEquals(true, settings.useGzip());
-    Assert.assertEquals("default", settings.getUserAgent());
+    Assert.assertEquals("abc", settings.getUserAgentPrefix());
+    Assert.assertEquals("xyz", settings.getUserAgentSuffix());
   }
 
   @Test
@@ -56,7 +57,6 @@ public class AwsClientFactoryTest {
     AwsClientFactory factory = new AwsClientFactory(config);
     ClientConfiguration settings = factory.createClientConfig("ec2-test");
     Assert.assertEquals(false, settings.useGzip());
-    Assert.assertNotEquals("default", settings.getUserAgent()); // should be default
   }
 
   @Test
@@ -64,7 +64,8 @@ public class AwsClientFactoryTest {
     AwsClientFactory factory = new AwsClientFactory(config);
     ClientConfiguration settings = factory.createClientConfig("ec2-test-default");
     Assert.assertEquals(false, settings.useGzip());
-    Assert.assertEquals("default", settings.getUserAgent());
+    Assert.assertEquals("abc", settings.getUserAgentPrefix());
+    Assert.assertEquals("xyz", settings.getUserAgentSuffix());
   }
 
   @Test

--- a/iep-module-aws/src/test/resources/aws-client-factory.conf
+++ b/iep-module-aws/src/test/resources/aws-client-factory.conf
@@ -3,7 +3,8 @@ netflix.iep.aws {
 
   default {
     client {
-      user-agent = "default"
+      user-agent-prefix = "abc"
+      user-agent-suffix = "xyz"
       use-gzip = true
     }
   }

--- a/iep-ses/src/test/java/com/netflix/iep/ses/EmailRequestBuilderTest.java
+++ b/iep-ses/src/test/java/com/netflix/iep/ses/EmailRequestBuilderTest.java
@@ -81,8 +81,10 @@ public class EmailRequestBuilderTest {
       String message = builder.toString();
       writeResource(name, message.getBytes(StandardCharsets.US_ASCII));
     } else if (SEND) {
-      AmazonSimpleEmailService client = new AmazonSimpleEmailServiceClient(
-          new DefaultAWSCredentialsProviderChain());
+      AmazonSimpleEmailService client = AmazonSimpleEmailServiceClient.builder()
+          .withCredentials(new DefaultAWSCredentialsProviderChain())
+          .withRegion("us-east-1")
+          .build();
       client.sendRawEmail(builder.build());
     } else {
       String message = builder.toString();


### PR DESCRIPTION
Fixes some deprecation warnings with recent AWS SDK by
switching to use the builders for clients. This change
also allows us to simplify the config because we only
need to know the region, not the full endpointn that we
need to construct. The config has been simplified to
only include overrides for services like SES and Route53
where the service is not available in all of the regions
where we need to access them.