### PR TITLE
allow valid tag chars to be set in typesafe config

### DIFF
--- a/iep-module-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
+++ b/iep-module-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -129,6 +130,23 @@ class AtlasRegistryService extends AbstractService {
         }
       }
       return tags;
+    }
+
+    @Override public String validTagCharacters() {
+      String pattern = get("atlas.validTagCharacters");
+      return (pattern == null) ? "-._A-Za-z0-9" : pattern;
+    }
+
+    @Override public Map<String, String> validTagValueCharacters() {
+      if (config.hasPath("atlas.validTagValueCharacters")) {
+        Map<String, String> tags = new HashMap<>();
+        for (Config cfg : config.getConfigList("atlas.validTagValueCharacters")) {
+          tags.put(cfg.getString("key"), cfg.getString("value"));
+        }
+        return tags;
+      } else {
+        return Collections.emptyMap();
+      }
     }
   }
 }

--- a/iep-module-atlas/src/main/resources/reference.conf
+++ b/iep-module-atlas/src/main/resources/reference.conf
@@ -43,6 +43,19 @@ netflix.iep.atlas {
     }
   ]
 
+  validTagCharacters = "-._A-Za-z0-9"
+
+  validTagValueCharacters = ${?netflix.iep.atlas.validTagValueCharacters} [
+    {
+      key = "nf.cluster"
+      value = "-._A-Za-z0-9^~"
+    },
+    {
+      key = "nf.asg"
+      value = "-._A-Za-z0-9^~"
+    }
+  ]
+
   collection {
     jvm = true
     gc = true

--- a/iep-module-atlas/src/test/java/com/netflix/iep/atlas/AtlasRegistryServiceTest.java
+++ b/iep-module-atlas/src/test/java/com/netflix/iep/atlas/AtlasRegistryServiceTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.atlas;
+
+import com.netflix.spectator.atlas.AtlasConfig;
+import com.netflix.spectator.atlas.AtlasRegistry;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AtlasRegistryServiceTest {
+
+  @Test
+  public void validTagCharacters() throws Exception {
+    AtlasRegistryService service = new AtlasRegistryService();
+    AtlasRegistry registry = (AtlasRegistry) service.getRegistry();
+    AtlasConfig config = (AtlasConfig) registry.config();
+    Assert.assertEquals("-._A-Za-z0-9", config.validTagCharacters());
+    Assert.assertEquals("-._A-Za-z0-9^~", config.validTagValueCharacters().get("nf.cluster"));
+    Assert.assertEquals("-._A-Za-z0-9^~", config.validTagValueCharacters().get("nf.asg"));
+    Assert.assertNull(config.validTagValueCharacters().get("nf.zone"));
+    service.stop();
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val rxscala    = "0.26.4"
     val scala      = "2.11.8"
     val slf4j      = "1.7.23"
-    val spectator  = "0.52.0"
+    val spectator  = "0.53.0"
   }
 
   import Versions._


### PR DESCRIPTION
Update the reference config and wrapper impl to support
the valid tag character settings that were added in 0.53.0:
https://github.com/Netflix/spectator/pull/378.