### PR TITLE
allow CLOUD_ env vars if set to be used

### DIFF
--- a/iep-nflxenv/src/main/resources/reference.conf
+++ b/iep-nflxenv/src/main/resources/reference.conf
@@ -30,33 +30,47 @@ netflix.iep.env {
 
   account = "test"
   account = ${?NETFLIX_ACCOUNT}
+  account = ${?CLOUD_ACCOUNT}
   account-env = "test"
   account-env = ${?NETFLIX_ENVIRONMENT}
+  account-env = ${?CLOUD_ENVIRONMENT}
   account-env = ${?NETFLIX_ACCOUNT_ENV}
+  account-env = ${?CLOUD_ACCOUNT_ENV}
   account-type = "main"
   account-type = ${?NETFLIX_ACCOUNT_TYPE}
+  account-type = ${?CLOUD_ACCOUNT_TYPE}
 
   // If you need to use this field, install the pluggable-accounts package.
   insight-account-id = "unknown"
+  insight-account-id = ${?EC2_OWNER_ID}
   insight-account-id = ${?INSIGHT_ACCOUNT_ID}
 
   // With newer user data this should only ever be "test" or "prod". In most cases
   // account-env should be preferred.
   environment = "test"
   environment = ${?NETFLIX_ENVIRONMENT}
+  environment = ${?CLOUD_ENVIRONMENT}
+
+  domain = "localhost"
+  domain = ${?NETFLIX_DOMAIN}
+  domain = ${?CLOUD_DOMAIN}
 
   vpc-id = "classic"
   vpc-id = ${?EC2_VPC_ID}
 
   app = "local"
   app = ${?NETFLIX_APP}
+  app = ${?CLOUD_APP}
 
   cluster = "local-dev"
   cluster = ${?NETFLIX_CLUSTER}
+  cluster = ${?CLOUD_CLUSTER}
 
   asg = "local-dev"
   asg = ${?NETFLIX_AUTO_SCALE_GROUP}
+  asg = ${?CLOUD_AUTO_SCALE_GROUP}
 
   stack = "dev"
   stack = ${?NETFLIX_STACK}
+  stack = ${?CLOUD_STACK}
 }


### PR DESCRIPTION
When working with groups outside Netflix based on
zerotocloud, this makes it easier to get started
spinning up a similar baseami.

Also adds the `domain` setting to allow an easy
substitution for creating DNS names in some configs.