### PR TITLE
add additional build metadata to jar

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -48,7 +48,12 @@ object BuildSettings {
       IO.write(
         credentialsFile,
         bintray.BintrayCredentials.api.template(Bintray.user, Bintray.pass))
-    }
+    },
+
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+      "Build-Date"   -> java.time.Instant.now().toString,
+      "Build-Number" -> sys.env.getOrElse("TRAVIS_BUILD_NUMBER", "unknown"),
+      "Commit"       -> sys.env.getOrElse("TRAVIS_COMMIT",       "unknown"))
   )
 
   lazy val commonDeps = Seq(


### PR DESCRIPTION
Add the build date and number to the jar manifest
to aid in debugging.