### PR TITLE
utility class for helping with aws pagination

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,9 +139,17 @@ lazy val `iep-module-aws` = project
   .dependsOn(`iep-nflxenv`)
   .settings(libraryDependencies ++= Seq(
     Dependencies.awsCore,
+    Dependencies.awsAutoScaling % "test",
+    Dependencies.awsCloudWatch % "test",
     Dependencies.awsEC2 % "test",
+    Dependencies.awsELB % "test",
+    Dependencies.awsELBv2 % "test",
+    Dependencies.awsEMR % "test",
+    Dependencies.awsRoute53 % "test",
     Dependencies.awsSTS,
     Dependencies.guiceCore,
+    Dependencies.reactiveStreams,
+    Dependencies.rxjava2,
     Dependencies.slf4jApi,
     Dependencies.typesafeConfig
   ))

--- a/iep-module-aws/src/main/java/com/netflix/iep/aws/Pagination.java
+++ b/iep-module-aws/src/main/java/com/netflix/iep/aws/Pagination.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.aws;
+
+import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
+import org.reactivestreams.Publisher;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * Helper for paginating AWS requests.
+ */
+public final class Pagination {
+
+
+  private static final Executor DEFAULT_POOL = Executors.newCachedThreadPool(new ThreadFactory() {
+    private final AtomicInteger nextId = new AtomicInteger();
+    @Override public Thread newThread(Runnable r) {
+      return new Thread(r, "aws-publisher-" + nextId.getAndIncrement());
+    }
+  });
+
+  private static final String[] GET_NEXT = {
+    "getNextToken", "getNextMarker", "getMarker"
+  };
+
+  private static final String[] SET_NEXT = {
+    "setNextToken", "setMarker", "setMarker"
+  };
+
+  /**
+   * Create an iterator over all results for a given request type. Example usage:
+   *
+   * <pre>
+   * AmazonEC2 ec2Client = ...
+   * Iterator&lt;DescribeInstancesResult&gt; it =
+   *   Pagination.createIterator(new DescribeInstancesRequest(), client::describeInstances);
+   * while (it.hasNext()) {
+   *   DescribeInstancesResult result = it.next();
+   *   ...
+   * }
+   * </pre>
+   *
+   * @param request
+   *     Initial request to send. This request will get modified with the new page token
+   *     for subsequent requests so it should not be shared across calls.
+   * @param f
+   *     Function for mapping the request to a result.
+   * @return
+   *     Iterator over all results for a given request.
+   */
+  public static <R, T> Iterator<T> createIterator(R request, Function<R, T> f) {
+    return new Iterator<T>() {
+      private R nextReq = request;
+      private T res = null;
+
+      @Override public boolean hasNext() {
+        return nextReq != null;
+      }
+
+      @Override public T next() {
+        res = f.apply(nextReq);
+        nextReq = getNextRequest(nextReq, res);
+        return res;
+      }
+    };
+  }
+
+  /**
+   * Create an iterable for obtaining an iterator over all results for a given request type.
+   * Example usage:
+   *
+   * <pre>
+   * AmazonEC2 ec2Client = ...
+   * DescribeInstancesRequest req = new DescribeInstancesRequest();
+   * for (DescribeInstancesResult res : Pagination.createIterable(req, client::desribeInstances)) {
+   *   ...
+   * }
+   * </pre>
+   *
+   * @param request
+   *     Initial request to send. This request will get modified with the new page token
+   *     for subsequent requests so it should not be shared across calls.
+   * @param f
+   *     Function for mapping the request to a result.
+   * @return
+   *     Iterable for obtaining an iterator over all results for a given request.
+   */
+  public static <R, T> Iterable<T> createIterable(R request, Function<R, T> f) {
+    return () -> createIterator(request, f);
+  }
+
+  /**
+   * Create a reactive streams publisher for obtaining all results for a given request type.
+   * The requests will be made using a cached thread pool that will spin up new threads as
+   * needed. Example usage with rxjava2:
+   *
+   * <pre>
+   * AmazonEC2 ec2Client = ...
+   * DescribeInstancesRequest req = new DescribeInstancesRequest();
+   * Iterable&lt;String&gt; instanceIds = Flowable
+   *   .fromPublisher(Pagination.createPublisher(req, client::describeInstances))
+   *   .flatMap(r -> Flowable.fromIterable(r.getReservations()))
+   *   .flatMap(r -> Flowable.fromIterable(r.getInstances()))
+   *   .map(Instance::getInstanceId)
+   *   .blockingIterable();
+   * for (String instanceId : instanceIds) {
+   *   ...
+   * }
+   * </pre>
+   *
+   * @param request
+   *     Initial request to send. This request will get modified with the new page token
+   *     for subsequent requests so it should not be shared across calls.
+   * @param f
+   *     Function for mapping the request to a result.
+   * @return
+   *     Publisher for obtaining all results for a given request.
+   */
+  public static <R, T> Publisher<T> createPublisher(R request, Function<R, T> f) {
+    return createPublisher(DEFAULT_POOL, request, f);
+  }
+
+  /**
+   * Create a reactive streams publisher for obtaining all results for a given request type.
+   * Example usage with rxjava2:
+   *
+   * <pre>
+   * Executor myPool = Executors.newFixedThreadPool(10);
+   * AmazonEC2 ec2Client = ...
+   * DescribeInstancesRequest req = new DescribeInstancesRequest();
+   * Iterable&lt;String&gt; instanceIds = Flowable
+   *   .fromPublisher(Pagination.createPublisher(myPool, req, client::describeInstances))
+   *   .flatMap(r -> Flowable.fromIterable(r.getReservations()))
+   *   .flatMap(r -> Flowable.fromIterable(r.getInstances()))
+   *   .map(Instance::getInstanceId)
+   *   .blockingIterable();
+   * for (String instanceId : instanceIds) {
+   *   ...
+   * }
+   * </pre>
+   *
+   * @param executor
+   *     Executor that will be used for making the AWS requests.
+   * @param request
+   *     Initial request to send. This request will get modified with the new page token
+   *     for subsequent requests so it should not be shared across calls.
+   * @param f
+   *     Function for mapping the request to a result.
+   * @return
+   *     Publisher for obtaining all results for a given request.
+   */
+  public static <R, T> Publisher<T> createPublisher(Executor executor, R request, Function<R, T> f) {
+    return Flowable.just(request)
+        .observeOn(Schedulers.from(executor))
+        .flatMap(r -> Flowable.fromIterable(createIterable(r, f)))
+        .observeOn(Schedulers.computation());
+  }
+
+  private static <R, T> R getNextRequest(R request, T result) {
+    try {
+      for (int i = 0; i < GET_NEXT.length; ++i) {
+        for (Method getter : result.getClass().getMethods()) {
+          if (getter.getName().equals(GET_NEXT[i])) {
+            Object next = getter.invoke(result);
+            if (next == null) {
+              return null;
+            } else {
+              Method setter = request.getClass().getMethod(SET_NEXT[i], String.class);
+              setter.invoke(request, next);
+              return request;
+            }
+          }
+        }
+      }
+      return null;
+    } catch (Exception e) {
+      throw new IllegalStateException("failed to set next token", e);
+    }
+  }
+
+}

--- a/iep-module-aws/src/test/java/com/netflix/iep/aws/PaginationTest.java
+++ b/iep-module-aws/src/test/java/com/netflix/iep/aws/PaginationTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.aws;
+
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest;
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult;
+import com.amazonaws.services.cloudwatch.model.ListMetricsRequest;
+import com.amazonaws.services.cloudwatch.model.ListMetricsResult;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataResult;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest;
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult;
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest;
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult;
+import com.amazonaws.services.elasticmapreduce.model.ListClustersRequest;
+import com.amazonaws.services.elasticmapreduce.model.ListClustersResult;
+import com.amazonaws.services.route53.model.ListHostedZonesRequest;
+import com.amazonaws.services.route53.model.ListHostedZonesResult;
+import io.reactivex.Flowable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.reactivestreams.Publisher;
+
+import java.util.Iterator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+@RunWith(JUnit4.class)
+public class PaginationTest {
+
+  private SortedSet<String> newPageSet(int n) {
+    SortedSet<String> pages = new TreeSet<>();
+    for (int i = 0; i < n; ++i) {
+      pages.add(String.format("%05d", i));
+    }
+    return pages;
+  }
+
+  private void autoscalingN(int n) throws Exception {
+    SortedSet<String> pages = newPageSet(n);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<DescribeAutoScalingGroupsRequest, DescribeAutoScalingGroupsResult> f = r -> {
+      if (r.getNextToken() != null) {
+        Assert.assertEquals(reqIt.next(), r.getNextToken());
+      }
+      return new DescribeAutoScalingGroupsResult()
+          .withNextToken(resIt.hasNext() ? resIt.next() : null);
+    };
+
+    Publisher<DescribeAutoScalingGroupsResult> publisher =
+        Pagination.createPublisher(new DescribeAutoScalingGroupsRequest(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.getNextToken() != null)
+        .map(DescribeAutoScalingGroupsResult::getNextToken)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void autoscaling() throws Exception {
+    autoscalingN(5);
+  }
+
+  @Test
+  public void autoscalingNoStackOverflow() throws Exception {
+    autoscalingN(10000);
+  }
+
+  @Test
+  public void cloudwatch() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<ListMetricsRequest, ListMetricsResult> f = r -> {
+      if (r.getNextToken() != null) {
+        Assert.assertEquals(reqIt.next(), r.getNextToken());
+      }
+      return new ListMetricsResult()
+          .withNextToken(resIt.hasNext() ? resIt.next() : null);
+    };
+
+    Publisher<ListMetricsResult> publisher =
+        Pagination.createPublisher(new ListMetricsRequest(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.getNextToken() != null)
+        .map(ListMetricsResult::getNextToken)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void cloudwatchPut() throws Exception {
+    final AtomicInteger n = new AtomicInteger();
+    Function<PutMetricDataRequest, PutMetricDataResult> f = r -> {
+      if (n.getAndIncrement() > 0) {
+        Assert.fail("non-paginated API called more than once");
+      }
+      return new PutMetricDataResult();
+    };
+
+    Publisher<PutMetricDataResult> publisher =
+        Pagination.createPublisher(new PutMetricDataRequest(), f);
+    Iterable<PutMetricDataResult> iter = Flowable.fromPublisher(publisher).blockingIterable();
+
+    int count = 0;
+    for (PutMetricDataResult r : iter) {
+      ++count;
+    }
+
+    Assert.assertEquals(1, count);
+  }
+
+  @Test
+  public void ec2() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<DescribeInstancesRequest, DescribeInstancesResult> f = r -> {
+      if (r.getNextToken() != null) {
+        Assert.assertEquals(reqIt.next(), r.getNextToken());
+      }
+      return new DescribeInstancesResult()
+          .withNextToken(resIt.hasNext() ? resIt.next() : null);
+    };
+
+    Publisher<DescribeInstancesResult> publisher =
+        Pagination.createPublisher(new DescribeInstancesRequest(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.getNextToken() != null)
+        .map(DescribeInstancesResult::getNextToken)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void elb() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<DescribeLoadBalancersRequest, DescribeLoadBalancersResult> f = r -> {
+      if (r.getMarker() != null) {
+        Assert.assertEquals(reqIt.next(), r.getMarker());
+      }
+      return new DescribeLoadBalancersResult()
+          .withNextMarker(resIt.hasNext() ? resIt.next() : null);
+    };
+
+    Publisher<DescribeLoadBalancersResult> publisher =
+        Pagination.createPublisher(new DescribeLoadBalancersRequest(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.getNextMarker() != null)
+        .map(DescribeLoadBalancersResult::getNextMarker)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void elbv2() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<DescribeTargetGroupsRequest, DescribeTargetGroupsResult> f = r -> {
+      if (r.getMarker() != null) {
+        Assert.assertEquals(reqIt.next(), r.getMarker());
+      }
+      return new DescribeTargetGroupsResult()
+          .withNextMarker(resIt.hasNext() ? resIt.next() : null);
+    };
+
+    Publisher<DescribeTargetGroupsResult> publisher =
+        Pagination.createPublisher(new DescribeTargetGroupsRequest(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.getNextMarker() != null)
+        .map(DescribeTargetGroupsResult::getNextMarker)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void emr() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<ListClustersRequest, ListClustersResult> f = r -> {
+      if (r.getMarker() != null) {
+        Assert.assertEquals(reqIt.next(), r.getMarker());
+      }
+      return new ListClustersResult()
+          .withMarker(resIt.hasNext() ? resIt.next() : null);
+    };
+
+    Publisher<ListClustersResult> publisher =
+        Pagination.createPublisher(new ListClustersRequest(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.getMarker() != null)
+        .map(ListClustersResult::getMarker)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void route53() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<ListHostedZonesRequest, ListHostedZonesResult> f = r -> {
+      if (r.getMarker() != null) {
+        Assert.assertEquals(reqIt.next(), r.getMarker());
+      }
+      return new ListHostedZonesResult()
+          .withNextMarker(resIt.hasNext() ? resIt.next() : null);
+    };
+
+    Publisher<ListHostedZonesResult> publisher =
+        Pagination.createPublisher(new ListHostedZonesRequest(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.getNextMarker() != null)
+        .map(ListHostedZonesResult::getNextMarker)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,8 +22,14 @@ object Dependencies {
   val archaiusLegacy   = "com.netflix.archaius" % "archaius-core" % "0.7.4"
   val archaiusPersist  = "com.netflix.archaius" % "archaius2-persisted2" % archaius
   val archaiusTypesafe = "com.netflix.archaius" % "archaius2-typesafe" % archaius
+  val awsAutoScaling   = "com.amazonaws" % "aws-java-sdk-autoscaling" % aws
   val awsCore          = "com.amazonaws" % "aws-java-sdk-core" % aws
+  val awsCloudWatch    = "com.amazonaws" % "aws-java-sdk-cloudwatch" % aws
   val awsEC2           = "com.amazonaws" % "aws-java-sdk-ec2" % aws
+  val awsELB           = "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % aws
+  val awsELBv2         = "com.amazonaws" % "aws-java-sdk-elasticloadbalancingv2" % aws
+  val awsEMR           = "com.amazonaws" % "aws-java-sdk-emr" % aws
+  val awsRoute53       = "com.amazonaws" % "aws-java-sdk-route53" % aws
   val awsSES           = "com.amazonaws" % "aws-java-sdk-ses" % aws
   val awsSTS           = "com.amazonaws" % "aws-java-sdk-sts" % aws
   val equalsVerifier   = "nl.jqno.equalsverifier" % "equalsverifier" % "2.2.1"
@@ -44,7 +50,9 @@ object Dependencies {
   val junit            = "junit" % "junit" % "4.12"
   val junitInterface   = "com.novocode" % "junit-interface" % "0.11"
   val jzlib            = "com.jcraft" % "jzlib" % "1.1.3"
+  val reactiveStreams  = "org.reactivestreams" % "reactive-streams" % "1.0.0"
   val rxjava           = "io.reactivex" % "rxjava" % "1.2.6"
+  val rxjava2          = "io.reactivex.rxjava2" % "rxjava" % "2.0.8"
   val rxScala          = "io.reactivex" %% "rxscala" % rxscala
   val rxnettyCore      = "io.reactivex" % "rxnetty" % rxnetty
   val rxnettyCtxts     = "io.reactivex" % "rxnetty-contexts" % rxnetty


### PR DESCRIPTION
Adds a utility class that helps take care of pagination
for common AWS requests. This is a simpler alternative
to [rx-aws-java-sdk](https://github.com/Netflix/rx-aws-java-sdk).
Helper methods are aviable to create a simple blocking
iterable or a publisher that can be used with any reactive
streams implementation.