### PR TITLE
handle pagination for DynamoDB queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,6 +141,7 @@ lazy val `iep-module-aws` = project
     Dependencies.awsCore,
     Dependencies.awsAutoScaling % "test",
     Dependencies.awsCloudWatch % "test",
+    Dependencies.awsDynamoDB % "test",
     Dependencies.awsEC2 % "test",
     Dependencies.awsELB % "test",
     Dependencies.awsELBv2 % "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,6 +25,7 @@ object Dependencies {
   val awsAutoScaling   = "com.amazonaws" % "aws-java-sdk-autoscaling" % aws
   val awsCore          = "com.amazonaws" % "aws-java-sdk-core" % aws
   val awsCloudWatch    = "com.amazonaws" % "aws-java-sdk-cloudwatch" % aws
+  val awsDynamoDB      = "com.amazonaws" % "aws-java-sdk-dynamodb" % aws
   val awsEC2           = "com.amazonaws" % "aws-java-sdk-ec2" % aws
   val awsELB           = "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % aws
   val awsELBv2         = "com.amazonaws" % "aws-java-sdk-elasticloadbalancingv2" % aws


### PR DESCRIPTION
It is based on `getLastEvaluatedKey` and
`setExclusiveStartKey`. The other change
is that the token no longer has to be a
String since DynamoDB uses a map.