### PR TITLE
fix ability to disable redirects with RxHttp

### DIFF
--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/RxHttp.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/RxHttp.java
@@ -565,7 +565,8 @@ public final class RxHttp {
 
     HttpClient.HttpClientConfig.Builder configBuilder = new HttpClient.HttpClientConfig.Builder()
         .readTimeout(clientCfg.readTimeout(), TimeUnit.MILLISECONDS)
-        .userAgent(clientCfg.userAgent());
+        .userAgent(clientCfg.userAgent())
+        .setFollowRedirect(false);
 
     int subscribeTimeout = clientCfg.contentSubscribeTimeout();
     if (subscribeTimeout > 0)


### PR DESCRIPTION
The default redirect handler in RxNetty would cause them
to get followed even if disabled in RxHttp config. Also,
the redirect handler would always try to redirect at least
once.