### PR TITLE
update base version to 1.0.x

### DIFF
--- a/project/GitVersion.scala
+++ b/project/GitVersion.scala
@@ -6,7 +6,7 @@ import com.typesafe.sbt.SbtGit._
 object GitVersion {
 
   // Base version for master branch
-  private val baseVersion = "v0.4.x"
+  private val baseVersion = "v1.0.x"
 
   // 0.1.x
   private val versionBranch = """v?([0-9\.]+)(?:\.x)?""".r


### PR DESCRIPTION
This should cause the snapshots to publish
with the correct version.