### PR TITLE
add support for loading context specific configs

### DIFF
--- a/iep-platformservice/src/main/resources/reference.conf
+++ b/iep-platformservice/src/main/resources/reference.conf
@@ -1,4 +1,10 @@
 
+// Names of additional config files to load after the base layer. This allows for
+// substitutions using environment variables or system properties which are not
+// supported with the default include mechanism. See:
+// https://github.com/typesafehub/config/issues/122
+netflix.iep.include = []
+
 netflix.iep.archaius {
   use-dynamic = true
   sync-init = true

--- a/iep-platformservice/src/test/java/com/netflix/iep/platformservice/PlatformServiceModuleTest.java
+++ b/iep-platformservice/src/test/java/com/netflix/iep/platformservice/PlatformServiceModuleTest.java
@@ -101,4 +101,18 @@ public class PlatformServiceModuleTest {
     Assert.assertEquals("b", root.getString("a"));
     Assert.assertEquals("runtime", root.getString("c"));
   }
+
+  @Test
+  public void includesAreLoaded() {
+    PlatformServiceModule m = new PlatformServiceModule();
+    com.typesafe.config.Config c = m.providesTypesafeConfig();
+    Assert.assertEquals("abc", c.getString("includes.a"));
+  }
+
+  @Test
+  public void includesLaterFilesOverride() {
+    PlatformServiceModule m = new PlatformServiceModule();
+    com.typesafe.config.Config c = m.providesTypesafeConfig();
+    Assert.assertEquals("def:main", c.getString("includes.b"));
+  }
 }

--- a/iep-platformservice/src/test/resources/a.conf
+++ b/iep-platformservice/src/test/resources/a.conf
@@ -1,0 +1,3 @@
+
+includes.a = abc
+includes.b = def

--- a/iep-platformservice/src/test/resources/application.conf
+++ b/iep-platformservice/src/test/resources/application.conf
@@ -1,3 +1,9 @@
 
 // Test property for check to ensure application.conf is loaded as expected
 iep.test.which-config = app
+
+netflix.iep.include = [
+  "a.conf",
+  "c.conf",
+  "c.conf"
+]

--- a/iep-platformservice/src/test/resources/c.conf
+++ b/iep-platformservice/src/test/resources/c.conf
@@ -1,0 +1,2 @@
+
+includes.b = "def:"${netflix.iep.env.account-type}


### PR DESCRIPTION
Adds a setting that can be used to load additional
config files based on settings in the base config.
This is typically used to load a config file specific
to a given cluster or environment that can be determined
from the environment variables on the system.