### PR TITLE
remove scm block from pom extras

### DIFF
--- a/project/Bintray.scala
+++ b/project/Bintray.scala
@@ -32,10 +32,6 @@ object Bintray {
 
     pomExtra :=
       <url>https://github.com/netflix/iep/wiki</url>
-      <scm>
-        <url>git@github.com:netflix/iep.git</url>
-        <connection>scm:git:git@github.com:netflix/iep.git</connection>
-      </scm>
       <developers>
         <developer>
           <id>brharrington</id>


### PR DESCRIPTION
The newer version of sbt-bintray adds the scm block
to the pom automatically. Having duplicate scm sections
in the pom causes errors when submitting to bintray (#321).