### PR TITLE
fix #320, move `in` outside the if

### DIFF
--- a/project/Bintray.scala
+++ b/project/Bintray.scala
@@ -24,10 +24,11 @@ object Bintray {
     credentials += Credentials("Artifactory Realm", "oss.jfrog.org", user, pass),
 
     publishTo := {
+      val defaultDestination = (publishTo in bintray value)
       if (isSnapshot.value)
         Some("OJO" at s"https://oss.jfrog.org/oss-snapshot-local;build.timestamp=$now/")
       else
-        publishTo in bintray value
+        defaultDestination
     },
 
     pomExtra :=


### PR DESCRIPTION
Avoids errors when running on newer versions of
sbt:

```
[error] iep/project/Bintray.scala:30:19: The evaluation of `in` happens always inside a regular task.
[error]
[error] Problem: `in` is inside the if expression of a regular task.
[error]   Regular tasks always evaluate task inside the bodies of if expressions.
[error]
[error] Solution:
[error]   1. If you only want to evaluate it when the if predicate is true or false, use a dynamic task.
[error]   2. Otherwise, make the static evaluation explicit by evaluating `in` outside the if expression.
[error]
[error]         publishTo in bintray value
[error]                   ^
[error] one error found
[error] (compile:compileIncremental) Compilation failed
```