### PR TITLE
support java.time types on config interface

### DIFF
--- a/iep-config/src/main/java/com/netflix/iep/config/Strings.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/Strings.java
@@ -15,12 +15,15 @@
  */
 package com.netflix.iep.config;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-//import org.joda.time.DateTimeZone.UTC;
 import org.joda.time.Duration;
 import org.joda.time.Period;
 import org.joda.time.format.ISODateTimeFormat;
@@ -96,32 +99,33 @@ public class Strings {
   }
 
   public static boolean conversionExists(Class c) {
-    return c == String.class ||
-    c == boolean.class ||
-    c == byte.class ||
-    c == short.class ||
-    c == int.class ||
-    c == long.class ||
-    c == float.class ||
-    c == double.class ||
-    //c == Number.class ||
-    c == Boolean.class ||
-    c == Byte.class ||
-    c == Short.class ||
-    c == Integer.class ||
-    c == Long.class ||
-    c == Float.class ||
-    c == Double.class ||
-    c == DateTime.class ||
-    c == DateTimeZone.class ||
-    c == Duration.class ||
-    c == Period.class ||
-    c == Pattern.class;
+    return c == String.class
+        || c == boolean.class
+        || c == byte.class
+        || c == short.class
+        || c == int.class
+        || c == long.class
+        || c == float.class
+        || c == double.class
+        || c == Boolean.class
+        || c == Byte.class
+        || c == Short.class
+        || c == Integer.class
+        || c == Long.class
+        || c == Float.class
+        || c == Double.class
+        || c == DateTime.class
+        || c == DateTimeZone.class
+        || c == Duration.class
+        || c == Period.class
+        || c == ZonedDateTime.class
+        || c == ZoneId.class
+        || c == java.time.Duration.class
+        || c == Pattern.class;
   }
 
   @SuppressWarnings("unchecked")
   public static <T> T cast(Class<T> c, String v) {
-    //if (c.isEnum()) return (T) enumValue(c, v);
     if (c == String.class) return (T) v;
     if (c == boolean.class) return (T) java.lang.Boolean.valueOf(v);
     if (c == byte.class) return (T) java.lang.Byte.valueOf(v);
@@ -130,7 +134,6 @@ public class Strings {
     if (c == long.class) return (T) java.lang.Long.valueOf(v);
     if (c == float.class) return (T) java.lang.Float.valueOf(v);
     if (c == double.class) return (T) java.lang.Double.valueOf(v);
-    //if (c == Number.class) return (T) java.lang.Number.valueOf(v);
     if (c == Boolean.class) return (T) java.lang.Boolean.valueOf(v);
     if (c == Byte.class) return (T) java.lang.Byte.valueOf(v);
     if (c == Short.class) return (T) java.lang.Short.valueOf(v);
@@ -142,8 +145,17 @@ public class Strings {
     if (c == DateTimeZone.class) return (T) DateTimeZone.forID(v);
     if (c == Duration.class) return (T) parseDuration(v);
     if (c == Period.class) return (T) parsePeriod(v);
+    if (c == ZonedDateTime.class) return (T) parseJavaDate(v);
+    if (c == ZoneId.class) return (T) ZoneId.of(v);
+    if (c == java.time.Duration.class) return (T) parseJavaDuration(v);
     if (c == Pattern.class) return (T) Pattern.compile(v);
     throw new IllegalArgumentException("unsupported property type " + c.getName());
+  }
+
+  private static ZonedDateTime parseJavaDate(String v) {
+    DateTime dt = parseDate(v);
+    long time = dt.toDate().getTime();
+    return ZonedDateTime.ofInstant(Instant.ofEpochMilli(time), ZoneOffset.UTC);
   }
 
   public static DateTime parseDate(String v) {
@@ -177,6 +189,11 @@ public class Strings {
     if (v.equals("now")) return new DateTime();
     else if (v.equals("epoch")) return epoch;
     else return ref;
+  }
+
+  private static java.time.Duration parseJavaDuration(String v) {
+    Duration d = parseDuration(v);
+    return java.time.Duration.ofMillis(d.getMillis());
   }
 
   public static Duration parseDuration(String v) {

--- a/iep-config/src/test/java/com/netflix/iep/config/ConfigurationTests.java
+++ b/iep-config/src/test/java/com/netflix/iep/config/ConfigurationTests.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.iep.config;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -56,6 +58,18 @@ public class ConfigurationTests {
 
     @DefaultValue("PT5M")
     Duration getDuration();
+
+    @DefaultValue("2014-08-01T00:00:00")
+    ZonedDateTime getJavaDateTime();
+
+    @DefaultValue("UTC")
+    ZoneId getZoneUTC();
+
+    @DefaultValue("US/Pacific")
+    ZoneId getZonePacific();
+
+    @DefaultValue("PT5M")
+    java.time.Duration getJavaDuration();
   }
 
   private TestConfig mkConfig() { return mkConfig(new HashMap<>()); }
@@ -171,5 +185,33 @@ public class ConfigurationTests {
     TestConfig config = mkConfig();
     Duration v = config.getDuration();
     assertEquals("getDuration", v.getMillis(), 300000L);
+  }
+
+  @Test
+  public void defaultJavaDateTime() {
+    TestConfig config = mkConfig();
+    ZonedDateTime v = config.getJavaDateTime();
+    assertEquals("getDateTime", v.toEpochSecond(), 1406851200L);
+  }
+
+  @Test
+  public void defaultJavaDuration() {
+    TestConfig config = mkConfig();
+    java.time.Duration v = config.getJavaDuration();
+    assertEquals("getDuration", v.toMillis(), 300000L);
+  }
+
+  @Test
+  public void zoneUTC() {
+    TestConfig config = mkConfig();
+    ZoneId v = config.getZoneUTC();
+    assertEquals("zoneUTC", v, ZoneId.of("UTC"));
+  }
+
+  @Test
+  public void zonePacific() {
+    TestConfig config = mkConfig();
+    ZoneId v = config.getZonePacific();
+    assertEquals("zonePacific", v, ZoneId.of("US/Pacific"));
   }
 }


### PR DESCRIPTION
The deprecated internal lib that predates this supports
java.time types instead of joda. With this change iep-config
will support both and so there will no longer be anything
preventing adoption and the old internal lib can go away.