### PR TITLE
disable eviction warnings for update task

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -39,6 +39,9 @@ object BuildSettings {
     autoScalaLibrary := false,
     externalResolvers := BuildSettings.resolvers,
 
+    // https://github.com/sbt/sbt/issues/1636
+    evictionWarningOptions in update := EvictionWarningOptions.empty,
+
     checkLicenseHeaders := License.checkLicenseHeaders(streams.value.log, sourceDirectory.value),
     formatLicenseHeaders := License.formatLicenseHeaders(streams.value.log, sourceDirectory.value),
 


### PR DESCRIPTION
Trying to clean up some of the noise in the build
logs. No one is paying attention to these warnings
and if there is a real compatibility problem it
should be caught in tests or the integration
environment.