### PR TITLE
support AutoCloseable for DI lifecycle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,8 @@ lazy val `iep-guice` = project
   .settings(libraryDependencies ++= Seq(
     Dependencies.guiceCore,
     Dependencies.guiceMulti,
-    Dependencies.slf4jApi
+    Dependencies.slf4jApi,
+    Dependencies.jsr250 % "test"
   ))
 
 lazy val `iep-launcher` = project

--- a/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
@@ -72,12 +72,11 @@ public class AdminServerTest {
     endpoints.put("/bad",  new BadEndpoint());
     endpoints.put("/test", new TestEndpoint());
     server = new AdminServer(config, endpoints);
-    server.start();
   }
 
   @After
-  public void after() {
-    server.stop();
+  public void after() throws Exception {
+    server.close();
   }
 
   private int getUnusedPort() throws IOException {

--- a/iep-config/src/main/java/com/netflix/iep/config/DynamicPropertiesConfiguration.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/DynamicPropertiesConfiguration.java
@@ -21,13 +21,12 @@ import com.netflix.archaius.api.PropertyFactory;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 
 @Singleton
-public class DynamicPropertiesConfiguration {
+public class DynamicPropertiesConfiguration implements AutoCloseable {
 
   private final IConfiguration instance;
 
@@ -59,8 +58,18 @@ public class DynamicPropertiesConfiguration {
     }
   }
 
-  @PreDestroy
+  /**
+   * @deprecated Use {@link #close()} instead.
+   */
   public void destroy() {
+    try {
+      close();
+    } catch (Exception e) {
+      throw new RuntimeException("failed to shutdown dynamic properties configuration", e);
+    }
+  }
+
+  @Override public void close() throws Exception {
     Configuration.setConfiguration(null);
   }
 }

--- a/iep-guice/src/main/java/com/netflix/iep/guice/PreDestroyList.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/PreDestroyList.java
@@ -45,6 +45,10 @@ public class PreDestroyList {
     int n = cleanupList.size();
     for (int i = n - 1; i >= 0; --i) {
       Object obj = cleanupList.get(i);
+      if (obj instanceof AutoCloseable) {
+        LOGGER.debug("invoking close() for {}", obj.getClass().getName());
+        ((AutoCloseable) obj).close();
+      }
       Method preDestroy = AnnotationUtils.getPreDestroy(obj.getClass());
       if (preDestroy != null) {
         LOGGER.debug("invoking @PreDestroy for {}", obj.getClass().getName());

--- a/iep-guice/src/test/java/com/netflix/iep/guice/LifecycleTest.java
+++ b/iep-guice/src/test/java/com/netflix/iep/guice/LifecycleTest.java
@@ -63,6 +63,23 @@ public class LifecycleTest {
   }
 
   @Test
+  public void autoCloseable() throws Exception {
+    GuiceHelper helper = new GuiceHelper();
+    helper.start(new AbstractModule() {
+      @Override protected void configure() {
+        bind(AutoStateObject.class);
+      }
+    });
+    Injector injector = helper.getInjector();
+
+    AutoStateObject obj = injector.getInstance(AutoStateObject.class);
+    Assert.assertEquals(State.STARTED, obj.getState());
+
+    helper.shutdown();
+    Assert.assertEquals(State.STOPPED, obj.getState());
+  }
+
+  @Test
   public void provides() throws Exception {
     GuiceHelper helper = new GuiceHelper();
     helper.start(new AbstractModule() {
@@ -132,6 +149,24 @@ public class LifecycleTest {
   private static class StateObjectProvider implements Provider<StateObject> {
     @Override public StateObject get() {
       return new StateObject();
+    }
+  }
+
+  private static class AutoStateObject implements AutoCloseable {
+
+    private State state;
+
+    @Inject
+    AutoStateObject() {
+      state = State.STARTED;
+    }
+
+    @Override public void close() throws Exception {
+      state = State.STOPPED;
+    }
+
+    State getState() {
+      return state;
     }
   }
 }

--- a/iep-module-admin/src/test/java/com/netflix/iep/admin/GuiceDebugEndpointTest.java
+++ b/iep-module-admin/src/test/java/com/netflix/iep/admin/GuiceDebugEndpointTest.java
@@ -48,7 +48,7 @@ public class GuiceDebugEndpointTest {
   @Test
   public void getString() {
     String response = endpoint.get("java.lang.String/value").toString();
-    Assert.assertTrue(response.startsWith("ArrayInfo([C, 3,"));
+    Assert.assertTrue(response, response.startsWith("ArrayInfo("));
   }
 
 }

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/Context.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/Context.java
@@ -20,10 +20,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.sandbox.HttpClient;
 import com.netflix.spectator.sandbox.HttpResponse;
 import com.typesafe.config.Config;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
@@ -34,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 /** Common settings used across all services. */
 @Singleton
-public final class Context {
+public final class Context implements AutoCloseable {
 
   private final ObjectMapper mapper = new ObjectMapper();
 
@@ -68,8 +65,19 @@ public final class Context {
     });
   }
 
-  @PreDestroy
+  /**
+   * @deprecated Use {@link #close()} instead.
+   */
+  @Deprecated
   public void stop() {
+    try {
+      close();
+    } catch (Exception e) {
+      throw new RuntimeException("failed to stop user service Context", e);
+    }
+  }
+
+  @Override public void close() throws Exception {
     executor.shutdown();
   }
 

--- a/iep-rxhttp/src/test/java/com/netflix/iep/http/RxHttpTest.java
+++ b/iep-rxhttp/src/test/java/com/netflix/iep/http/RxHttpTest.java
@@ -80,7 +80,6 @@ public class RxHttpTest {
 
   @BeforeClass
   public static void startServer() throws Exception {
-    rxHttp.start();
 
     server = HttpServer.create(new InetSocketAddress(0), 100);
     server.setExecutor(Executors.newFixedThreadPool(10, r -> new Thread(r, "HttpServer")));
@@ -189,8 +188,8 @@ public class RxHttpTest {
   }
 
   @AfterClass
-  public static void stopServer() {
-    rxHttp.stop();
+  public static void stopServer() throws Exception {
+    rxHttp.close();
     server.stop(0);
   }
 

--- a/iep-service/src/main/java/com/netflix/iep/service/AbstractService.java
+++ b/iep-service/src/main/java/com/netflix/iep/service/AbstractService.java
@@ -16,13 +16,12 @@
 package com.netflix.iep.service;
 
 import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 
 /**
  * Base class that manages the service state. Just implement the {@link #startImpl()} and
  * {@link #stopImpl()}.
  */
-public abstract class AbstractService implements Service {
+public abstract class AbstractService implements Service, AutoCloseable {
 
   private final String name;
   private volatile State state;
@@ -65,7 +64,6 @@ public abstract class AbstractService implements Service {
     }
   }
 
-  @PreDestroy
   public final synchronized void stop() throws Exception {
     if (state == State.STARTING || state == State.RUNNING) {
       state = State.STOPPING;
@@ -77,6 +75,14 @@ public abstract class AbstractService implements Service {
         throw e;
       }
     }
+  }
+
+  /**
+   * Equivalent to calling {@link #stop()}. This method is used for lifecycle management
+   * with DI frameworks.
+   */
+  @Override public void close() throws Exception {
+    stop();
   }
 
   protected abstract void startImpl() throws Exception;

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,6 +48,7 @@ object Dependencies {
   val jacksonSmile     = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % jackson
   val jodaConvert      = "org.joda" % "joda-convert" % "1.8.1"
   val jodaTime         = "joda-time" % "joda-time" % "2.9.7"
+  val jsr250           = "javax.annotation" % "jsr250-api" % "1.0"
   val junit            = "junit" % "junit" % "4.12"
   val junitInterface   = "com.novocode" % "junit-interface" % "0.11"
   val jzlib            = "com.jcraft" % "jzlib" % "1.1.3"


### PR DESCRIPTION
Fixes #324. Avoids needing JSR250 annotations for simple
use-cases doing constructor injection and optionally a
destruction method indicated by being `AutoCloseable`.

Several known issues still:

1. Pre destroy list should be limited to singletons.
2. iep-service still needs `@PostConstruct` because it is
   a base class and start cannot be invoked until after the
   sub-class constructor is complete.