### PR TITLE
only manage shutdown lifecycle for singletons

### DIFF
--- a/iep-guice/src/main/java/com/netflix/iep/guice/LifecycleModule.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/LifecycleModule.java
@@ -16,6 +16,7 @@
 package com.netflix.iep.guice;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
 import com.google.inject.matcher.Matchers;
 import com.google.inject.spi.ProvisionListener;
 import com.netflix.iep.service.ClassFactory;
@@ -39,7 +40,8 @@ public class LifecycleModule extends AbstractModule {
 
     @Override public <T> void onProvision(ProvisionInvocation<T> provisionInvocation) {
       T value = provisionInvocation.provision();
-      AnnotationUtils.invokePostConstruct(LOGGER, value, preDestroyList);
+      boolean singleton = Scopes.isSingleton(provisionInvocation.getBinding());
+      AnnotationUtils.invokePostConstruct(LOGGER, value, singleton ? preDestroyList : null);
     }
   }
 

--- a/iep-guice/src/test/java/com/netflix/iep/guice/LifecycleTest.java
+++ b/iep-guice/src/test/java/com/netflix/iep/guice/LifecycleTest.java
@@ -18,6 +18,7 @@ package com.netflix.iep.guice;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,7 +39,7 @@ public class LifecycleTest {
     helper.start();
     Injector injector = helper.getInjector();
 
-    StateObject obj = injector.getInstance(StateObject.class);
+    AutoStateObject obj = injector.getInstance(AutoStateObject.class);
     Assert.assertEquals(State.STARTED, obj.getState());
 
     helper.shutdown();
@@ -46,11 +47,27 @@ public class LifecycleTest {
   }
 
   @Test
+  public void justInTimeNotSingletonBinding() throws Exception {
+    GuiceHelper helper = new GuiceHelper();
+    helper.start();
+    Injector injector = helper.getInjector();
+
+    StateObject obj = injector.getInstance(StateObject.class);
+    Assert.assertEquals(State.STARTED, obj.getState());
+
+    helper.shutdown();
+
+    // Since it is not a singleton, caller is responsible for the object to avoid
+    // a leak due to keeping track objects that could be frequently created
+    Assert.assertEquals(State.STARTED, obj.getState());
+  }
+
+  @Test
   public void explicitBinding() throws Exception {
     GuiceHelper helper = new GuiceHelper();
     helper.start(new AbstractModule() {
       @Override protected void configure() {
-        bind(StateObject.class);
+        bind(StateObject.class).asEagerSingleton();
       }
     });
     Injector injector = helper.getInjector();
@@ -67,7 +84,7 @@ public class LifecycleTest {
     GuiceHelper helper = new GuiceHelper();
     helper.start(new AbstractModule() {
       @Override protected void configure() {
-        bind(AutoStateObject.class);
+        bind(AutoStateObject.class).asEagerSingleton();
       }
     });
     Injector injector = helper.getInjector();
@@ -106,7 +123,7 @@ public class LifecycleTest {
     GuiceHelper helper = new GuiceHelper();
     helper.start(new AbstractModule() {
       @Override protected void configure() {
-        bind(StateObject.class).toProvider(StateObjectProvider.class);
+        bind(StateObject.class).toProvider(StateObjectProvider.class).in(Scopes.SINGLETON);
       }
     });
     Injector injector = helper.getInjector();
@@ -152,6 +169,7 @@ public class LifecycleTest {
     }
   }
 
+  @Singleton
   private static class AutoStateObject implements AutoCloseable {
 
     private State state;


### PR DESCRIPTION
If the binding is not a singleton, then a new instance
will be created each time. To avoid a memory leak these
objects will not be managed automatically, the user will
need to close them.