### PR TITLE
add module with basic support for aws sdk 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
   include:
   - jdk: oraclejdk8
     env: BINTRAY_PUBLISH=true
+  allow_failures:
   - jdk: oraclejdk9
     env: BINTRAY_PUBLISH=false
 scala:

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val root = project.in(file("."))
     `iep-module-archaius2`,
     `iep-module-atlas`,
     `iep-module-aws`,
+    `iep-module-aws2`,
     `iep-module-awsmetrics`,
     `iep-module-eureka`,
     `iep-module-jmxport`,
@@ -123,6 +124,27 @@ lazy val `iep-module-aws` = project
     Dependencies.awsEMR % "test",
     Dependencies.awsRoute53 % "test",
     Dependencies.awsSTS,
+    Dependencies.guiceCore,
+    Dependencies.reactiveStreams,
+    Dependencies.rxjava2,
+    Dependencies.slf4jApi,
+    Dependencies.typesafeConfig
+  ))
+
+lazy val `iep-module-aws2` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`iep-nflxenv`)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.aws2Core,
+    Dependencies.aws2AutoScaling % "test",
+    Dependencies.aws2CloudWatch % "test",
+    Dependencies.aws2DynamoDB % "test",
+    Dependencies.aws2EC2 % "test",
+    Dependencies.aws2ELB % "test",
+    Dependencies.aws2ELBv2 % "test",
+    Dependencies.aws2EMR % "test",
+    Dependencies.aws2Route53 % "test",
+    Dependencies.aws2STS,
     Dependencies.guiceCore,
     Dependencies.reactiveStreams,
     Dependencies.rxjava2,

--- a/iep-module-aws2/README.md
+++ b/iep-module-aws2/README.md
@@ -1,0 +1,12 @@
+
+## Description
+
+Experimental bindings for [AWS SDK for Java 2][aws2].
+
+[aws2]: https://aws.amazon.com/blogs/developer/aws-sdk-for-java-2-0-developer-preview/
+
+## Gradle
+
+```
+compile "com.netflix.iep:iep-module-aws2:${version_iep}"
+```

--- a/iep-module-aws2/src/main/java/com/netflix/iep/aws2/AwsClientFactory.java
+++ b/iep-module-aws2/src/main/java/com/netflix/iep/aws2/AwsClientFactory.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.aws2;
+
+import com.typesafe.config.Config;
+import software.amazon.awssdk.auth.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.DefaultCredentialsProvider;
+import software.amazon.awssdk.client.builder.ClientBuilder;
+import software.amazon.awssdk.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.STSClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Factory for creating instances of AWS clients.
+ */
+@Singleton
+public class AwsClientFactory {
+
+  private final Config config;
+  private final String region;
+
+  @Inject
+  public AwsClientFactory(Config config) {
+    this.config = config;
+    this.region = config.getString("netflix.iep.aws.region");
+  }
+
+  private String firstOnly(String path) {
+    int pos = path.indexOf(".");
+    return (pos != -1) ? path.substring(0, pos) : path;
+  }
+
+  String getDefaultName(Class<?> cls) {
+    final String prefix = "software.amazon.awssdk.services.";
+    String pkg = cls.getPackage().getName();
+    return pkg.startsWith(prefix) ? firstOnly(pkg.substring(prefix.length())) : null;
+  }
+
+  private <T> void setIfPresent(Config cfg, String key, Function<String, T> getter, Consumer<T> setter) {
+    if (cfg.hasPath(key)) {
+      setter.accept(getter.apply(key));
+    }
+  }
+
+  private Config getConfig(String name, String suffix) {
+    final String cfgPrefix = "netflix.iep.aws";
+    return (name != null && config.hasPath(cfgPrefix + "." + name + "." + suffix))
+        ? config.getConfig(cfgPrefix + "." + name + "." + suffix)
+        : config.getConfig(cfgPrefix + ".default." + suffix);
+  }
+
+  ClientOverrideConfiguration createClientConfig(String name) {
+    final Config cfg = getConfig(name, "client");
+    final ClientOverrideConfiguration.Builder settings = ClientOverrideConfiguration.builder();
+
+    // Helpers
+    Function<String, Long> getMillis = k -> cfg.getDuration(k, TimeUnit.MILLISECONDS);
+    Function<String, Duration> getTimeout = cfg::getDuration;
+
+    // Typically use the defaults
+    setIfPresent(cfg, "use-gzip",                 cfg::getBoolean,  settings::gzipEnabled);
+    setIfPresent(cfg, "socket-timeout",           cfg::getDuration, settings::httpRequestTimeout);
+    setIfPresent(cfg, "client-execution-timeout", cfg::getDuration, settings::totalExecutionTimeout);
+    return settings.build();
+  }
+
+  private AwsCredentialsProvider createAssumeRoleProvider(Config cfg, AwsCredentialsProvider p) {
+    final String arn = cfg.getString("role-arn");
+    final String name = cfg.getString("role-session-name");
+    final STSClient stsClient = STSClient.builder()
+        .credentialsProvider(p)
+        .region(Region.of(region))
+        .build();
+    final AssumeRoleRequest request = AssumeRoleRequest.builder()
+        .roleArn(arn)
+        .roleSessionName(name)
+        .build();
+    return StsAssumeRoleCredentialsProvider.builder()
+        .stsClient(stsClient)
+        .refreshRequest(request)
+        .build();
+  }
+
+  AwsCredentialsProvider createCredentialsProvider(String name) {
+    final AwsCredentialsProvider dflt = DefaultCredentialsProvider.builder()
+        .asyncCredentialUpdateEnabled(true)
+        .build();
+    final Config cfg = getConfig(name, "credentials");
+    if (cfg.hasPath("role-arn")) {
+      return createAssumeRoleProvider(cfg, dflt);
+    } else {
+      return dflt;
+    }
+  }
+
+  private Region chooseRegion(String name, Class<?> cls) {
+    final String nameProp = "netflix.iep.aws." + name + ".region";
+    final String service = getDefaultName(cls);
+    final String dfltProp = "netflix.iep.aws.endpoint." + service + "." + region;
+    String endpointRegion = region;
+    if (config.hasPath(nameProp)) {
+      endpointRegion = config.getString(nameProp);
+    } else if (config.hasPath(dfltProp)) {
+      endpointRegion = config.getString(dfltProp);
+    }
+    return Region.of(endpointRegion);
+  }
+
+  public <T> T newInstance(Class<T> cls) {
+    return newInstance(getDefaultName(cls), cls);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> T newInstance(String name, Class<T> cls) {
+    try {
+      Method builderMethod = cls.getMethod("builder");
+      return (T) ((ClientBuilder) builderMethod.invoke(null))
+          .credentialsProvider(createCredentialsProvider(name))
+          .overrideConfiguration(createClientConfig(name))
+          .region(chooseRegion(name, cls))
+          .build();
+    } catch (Exception e) {
+      throw new RuntimeException("failed to create instance of " + cls.getName(), e);
+    }
+  }
+}

--- a/iep-module-aws2/src/main/java/com/netflix/iep/aws2/AwsModule.java
+++ b/iep-module-aws2/src/main/java/com/netflix/iep/aws2/AwsModule.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.aws2;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Creates a binding for an {@link AwsClientFactory}.
+ */
+public final class AwsModule extends AbstractModule {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AwsModule.class);
+
+  private static class OptionalInjections {
+    @Inject(optional = true)
+    private Config config;
+
+    Config getConfig() {
+      return (config == null) ? ConfigFactory.load(pickClassLoader()) : config;
+    }
+
+    private ClassLoader pickClassLoader() {
+      ClassLoader cl = Thread.currentThread().getContextClassLoader();
+      if (cl == null) {
+        LOGGER.warn("Thread.currentThread().getContextClassLoader() is null, using loader for {}",
+            getClass().getName());
+        cl = getClass().getClassLoader();
+      }
+      return cl;
+    }
+  }
+
+  @Override protected void configure() {
+  }
+
+  @Provides
+  private AwsClientFactory providesClientFactory(OptionalInjections opts) {
+    return new AwsClientFactory(opts.getConfig());
+  }
+
+  @Override public boolean equals(Object obj) {
+    return obj != null && getClass().equals(obj.getClass());
+  }
+
+  @Override public int hashCode() {
+    return getClass().hashCode();
+  }
+}

--- a/iep-module-aws2/src/main/java/com/netflix/iep/aws2/Pagination.java
+++ b/iep-module-aws2/src/main/java/com/netflix/iep/aws2/Pagination.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.aws2;
+
+import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
+import org.reactivestreams.Publisher;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * Helper for paginating AWS requests.
+ */
+public final class Pagination {
+
+  private Pagination() {
+  }
+
+  private static final Executor DEFAULT_POOL = Executors.newCachedThreadPool(new ThreadFactory() {
+    private final AtomicInteger nextId = new AtomicInteger();
+    @Override public Thread newThread(Runnable r) {
+      return new Thread(r, "aws-publisher-" + nextId.getAndIncrement());
+    }
+  });
+
+  // This is a positional list with corresponding entries in SET_NEXT. All entries will be
+  // attempted as some request types like ListResourceRecordSets have multiple keys.
+  //
+  // Note: getMarker must come before getNextMarker because sometimes both are present on the
+  // result and getMarker in that case represents the marker for the request that was already
+  // made.
+  private static final String[] GET_NEXT = {
+      "nextToken",
+      "marker",
+      "nextMarker",
+      "lastEvaluatedKey",
+      "nextRecordName",
+      "nextRecordType",
+      "nextRecordIdentifier"
+  };
+
+  private static final String[] SET_NEXT = {
+      "nextToken",
+      "marker",
+      "marker",
+      "exclusiveStartKey",
+      "startRecordName",
+      "startRecordType",
+      "startRecordIdentifier"
+  };
+
+  /**
+   * Create an iterator over all results for a given request type. Example usage:
+   *
+   * <pre>
+   * AmazonEC2 ec2Client = ...
+   * Iterator&lt;DescribeInstancesResult&gt; it =
+   *   Pagination.createIterator(new DescribeInstancesRequest(), client::describeInstances);
+   * while (it.hasNext()) {
+   *   DescribeInstancesResult result = it.next();
+   *   ...
+   * }
+   * </pre>
+   *
+   * @param request
+   *     Initial request to send. This request will get modified with the new page token
+   *     for subsequent requests so it should not be shared across calls.
+   * @param f
+   *     Function for mapping the request to a result.
+   * @return
+   *     Iterator over all results for a given request.
+   */
+  public static <R, T> Iterator<T> createIterator(R request, Function<R, T> f) {
+    return new Iterator<T>() {
+      private R nextReq = request;
+      private T res = null;
+
+      @Override public boolean hasNext() {
+        return nextReq != null;
+      }
+
+      @Override public T next() {
+        res = f.apply(nextReq);
+        nextReq = getNextRequest(nextReq, res);
+        return res;
+      }
+    };
+  }
+
+  /**
+   * Create an iterable for obtaining an iterator over all results for a given request type.
+   * Example usage:
+   *
+   * <pre>
+   * AmazonEC2 ec2Client = ...
+   * DescribeInstancesRequest req = new DescribeInstancesRequest();
+   * for (DescribeInstancesResult res : Pagination.createIterable(req, client::desribeInstances)) {
+   *   ...
+   * }
+   * </pre>
+   *
+   * @param request
+   *     Initial request to send. This request will get modified with the new page token
+   *     for subsequent requests so it should not be shared across calls.
+   * @param f
+   *     Function for mapping the request to a result.
+   * @return
+   *     Iterable for obtaining an iterator over all results for a given request.
+   */
+  public static <R, T> Iterable<T> createIterable(R request, Function<R, T> f) {
+    return () -> createIterator(request, f);
+  }
+
+  /**
+   * Create a reactive streams publisher for obtaining all results for a given request type.
+   * The requests will be made using a cached thread pool that will spin up new threads as
+   * needed. Example usage with rxjava2:
+   *
+   * <pre>
+   * AmazonEC2 ec2Client = ...
+   * DescribeInstancesRequest req = new DescribeInstancesRequest();
+   * Iterable&lt;String&gt; instanceIds = Flowable
+   *   .fromPublisher(Pagination.createPublisher(req, client::describeInstances))
+   *   .flatMap(r -> Flowable.fromIterable(r.getReservations()))
+   *   .flatMap(r -> Flowable.fromIterable(r.getInstances()))
+   *   .map(Instance::getInstanceId)
+   *   .blockingIterable();
+   * for (String instanceId : instanceIds) {
+   *   ...
+   * }
+   * </pre>
+   *
+   * @param request
+   *     Initial request to send. This request will get modified with the new page token
+   *     for subsequent requests so it should not be shared across calls.
+   * @param f
+   *     Function for mapping the request to a result.
+   * @return
+   *     Publisher for obtaining all results for a given request.
+   */
+  public static <R, T> Publisher<T> createPublisher(R request, Function<R, T> f) {
+    return createPublisher(DEFAULT_POOL, request, f);
+  }
+
+  /**
+   * Create a reactive streams publisher for obtaining all results for a given request type.
+   * Example usage with rxjava2:
+   *
+   * <pre>
+   * Executor myPool = Executors.newFixedThreadPool(10);
+   * AmazonEC2 ec2Client = ...
+   * DescribeInstancesRequest req = new DescribeInstancesRequest();
+   * Iterable&lt;String&gt; instanceIds = Flowable
+   *   .fromPublisher(Pagination.createPublisher(myPool, req, client::describeInstances))
+   *   .flatMap(r -> Flowable.fromIterable(r.getReservations()))
+   *   .flatMap(r -> Flowable.fromIterable(r.getInstances()))
+   *   .map(Instance::getInstanceId)
+   *   .blockingIterable();
+   * for (String instanceId : instanceIds) {
+   *   ...
+   * }
+   * </pre>
+   *
+   * @param executor
+   *     Executor that will be used for making the AWS requests.
+   * @param request
+   *     Initial request to send. This request will get modified with the new page token
+   *     for subsequent requests so it should not be shared across calls.
+   * @param f
+   *     Function for mapping the request to a result.
+   * @return
+   *     Publisher for obtaining all results for a given request.
+   */
+  public static <R, T> Publisher<T> createPublisher(Executor executor, R request, Function<R, T> f) {
+    return Flowable.just(request)
+        .observeOn(Schedulers.from(executor))
+        .flatMap(r -> Flowable.fromIterable(createIterable(r, f)))
+        .observeOn(Schedulers.computation());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <I, O> O invoke(I obj, String name) throws Exception {
+    Method m = obj.getClass().getMethod(name);
+    m.setAccessible(true);
+    return (O) m.invoke(obj);
+  }
+
+  private static <R, T> R getNextRequest(R request, T result) {
+    try {
+      Object builder = invoke(request, "toBuilder");
+      boolean hasNext = false;
+      for (int i = 0; i < GET_NEXT.length; ++i) {
+        for (Method getter : result.getClass().getMethods()) {
+          if (getter.getName().equals(GET_NEXT[i])) {
+            Object next = getter.invoke(result);
+            if (!isNullOrEmpty(next)) {
+              hasNext = true;
+              Method setter = builder.getClass().getMethod(SET_NEXT[i], getter.getReturnType());
+              setter.setAccessible(true);
+              setter.invoke(builder, next);
+            }
+          }
+        }
+      }
+      return hasNext ? invoke(builder, "build") : null;
+    } catch (Exception e) {
+      throw new IllegalStateException("failed to set next token", e);
+    }
+  }
+
+  private static boolean isNullOrEmpty(Object next) {
+    return (next == null) || (next instanceof Map && ((Map) next).isEmpty());
+  }
+}

--- a/iep-module-aws2/src/main/resources/META-INF/services/com.google.inject.Module
+++ b/iep-module-aws2/src/main/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.iep.aws.AwsModule

--- a/iep-module-aws2/src/main/resources/reference.conf
+++ b/iep-module-aws2/src/main/resources/reference.conf
@@ -1,0 +1,98 @@
+
+netflix.iep.aws {
+
+  // This should be the region that the app is running in.
+  region = "us-east-1"
+  region = ${?netflix.iep.env.region}
+
+  default {
+    credentials {
+      //role-arn = "arn:aws:iam::1234567890:role/IepTest"
+      //role-session-name = "iep"
+    }
+
+    client {
+      // For more information see:
+      // http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html
+      // http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/constant-values.html#com.amazonaws.ClientConfiguration.DEFAULT_CONNECTION_TIMEOUT
+      //use-reaper = true
+      //use-tcp-keep-alive = false
+      //use-throttle-retries = false
+      //max-connections = 50
+      //connection-ttl = 60s
+      //connection-max-idle = 60s
+      //connection-timeout = 50s
+      //socket-timeout = 50s
+
+      // Needs to be set to false for S3. If the client automatically decompresses the object
+      // content then the hash verification will fail:
+      //
+      // com.amazonaws.AmazonClientException: Unable to verify integrity of data download.
+      // Client calculated content hash didn't match hash calculated by Amazon S3. The data may
+      // be corrupt.
+      use-gzip = true
+      s3.use-gzip = false
+
+      // Defaults to -1, not set, but cannot be explicitly set to that value
+      //max-error-retry = -1
+
+      // Sometimes useful to customize for logging, but the default value is typically good enough.
+      // Sample of default:
+      // aws-sdk-java/1.8.9.1 Linux/3.2.0-54-virtual Java_HotSpot(TM)_64-Bit_Server_VM/25.0-b70/1.8.0
+      //user-agent-prefix
+      //user-agent-suffix
+
+      // If you need to proxy:
+      //proxy-port
+      //proxy-host
+      //proxy-domain
+      //proxy-workstation
+      //proxy-username
+      //proxy-password
+    }
+  }
+
+  // http://docs.aws.amazon.com/general/latest/gr/rande.html
+  // This is used to set overrides when a service is not available locally in the
+  // region we are running in.
+  endpoint {
+
+    cloudwatch {
+      us-nflx-1 = us-west-1
+    }
+
+    dynamodbv2 {
+      us-nflx-1 = us-west-1
+    }
+
+    route53 {
+      us-east-1 = us-east-1
+      us-west-2 = us-east-1
+      us-west-1 = us-east-1
+      eu-west-1 = us-east-1
+      eu-central-1 = us-east-1
+      ap-southeast-1 = us-east-1
+      ap-southeast-2 = us-east-1
+      ap-northeast-1 = us-east-1
+      sa-east-1 = us-east-1
+    }
+
+    simpleemail {
+      us-west-1 = us-west-2
+      eu-central-1 = eu-west-1
+      ap-southeast-1 = us-west-2
+      ap-southeast-2 = us-west-2
+      ap-northeast-1 = us-west-2
+      sa-east-1 = us-east-1
+      us-nflx-1 = us-west-2
+    }
+
+    sns {
+      us-nflx-1 = us-west-1
+    }
+
+    sqs {
+      us-nflx-1 = us-west-1
+    }
+  }
+}

--- a/iep-module-aws2/src/test/java/com/netflix/iep/aws2/AwsClientFactoryTest.java
+++ b/iep-module-aws2/src/test/java/com/netflix/iep/aws2/AwsClientFactoryTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.aws2;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import software.amazon.awssdk.auth.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.DefaultCredentialsProvider;
+import software.amazon.awssdk.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.services.ec2.EC2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeAddressesRequest;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+
+@RunWith(JUnit4.class)
+public class AwsClientFactoryTest {
+
+  private final Config config = ConfigFactory.load("aws-client-factory");
+
+  @Test
+  public void getDefaultName() {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    Assert.assertEquals("ec2", factory.getDefaultName(EC2Client.class));
+    Assert.assertEquals("ec2", factory.getDefaultName(DescribeAddressesRequest.class));
+  }
+
+  @Test
+  public void createClientConfig() {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    ClientOverrideConfiguration settings = factory.createClientConfig(null);
+    Assert.assertEquals(true, settings.gzipEnabled());
+  }
+
+  @Test
+  public void createClientConfigOverride() {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    ClientOverrideConfiguration settings = factory.createClientConfig("ec2-test");
+    Assert.assertEquals(false, settings.gzipEnabled());
+  }
+
+  @Test
+  public void createClientConfigOverrideWithDefaults() {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    ClientOverrideConfiguration settings = factory.createClientConfig("ec2-test-default");
+    Assert.assertEquals(false, settings.gzipEnabled());
+  }
+
+  @Test
+  public void createCredentialsProvider() {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    AwsCredentialsProvider creds = factory.createCredentialsProvider(null);
+    Assert.assertTrue(creds instanceof DefaultCredentialsProvider);
+  }
+
+  // Note: this is potentially fragile as it looks at private fields in the class. It is
+  // just an additional sanity check so the assertions can be commented out if they break.
+  private AssumeRoleRequest getRequest(AwsCredentialsProvider creds) throws Exception {
+    Class<?> cls = StsAssumeRoleCredentialsProvider.class;
+    Field f = cls.getDeclaredField("assumeRoleRequest");
+    f.setAccessible(true);
+    return (AssumeRoleRequest) f.get(creds);
+  }
+
+  @Test
+  public void createCredentialsProviderOverride() throws Exception {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    AwsCredentialsProvider creds = factory.createCredentialsProvider("ec2-test");
+    Assert.assertTrue(creds instanceof StsAssumeRoleCredentialsProvider);
+    Assert.assertEquals("arn:aws:iam::1234567890:role/IepTest", getRequest(creds).roleArn());
+    Assert.assertEquals("iep", getRequest(creds).roleSessionName());
+  }
+
+  @Test
+  public void newInstanceInterface() throws Exception {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    EC2Client ec2 = factory.newInstance(EC2Client.class);
+    Assert.assertNotNull(ec2);
+  }
+
+  @Test
+  public void newInstanceClient() throws Exception {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    EC2Client ec2 = factory.newInstance(EC2Client.class);
+    Assert.assertNotNull(ec2);
+  }
+
+  @Test
+  public void newInstanceName() throws Exception {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    EC2Client ec2 = factory.newInstance("ec2-test", EC2Client.class);
+    Assert.assertNotNull(ec2);
+  }
+
+  @Test
+  public void settingsBooleanTrue() {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    ClientOverrideConfiguration settings = factory.createClientConfig("boolean-true");
+    Assert.assertEquals(true, settings.gzipEnabled());
+  }
+
+  @Test
+  public void settingsBooleanFalse() {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    ClientOverrideConfiguration settings = factory.createClientConfig("boolean-false");
+    Assert.assertEquals(false, settings.gzipEnabled());
+  }
+
+  @Test
+  public void settingsTimeout() {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    ClientOverrideConfiguration settings = factory.createClientConfig("timeouts");
+    Assert.assertEquals(Duration.ofMillis(42000), settings.httpRequestTimeout());
+    Assert.assertEquals(Duration.ofMillis(13000), settings.totalExecutionTimeout());
+  }
+}

--- a/iep-module-aws2/src/test/java/com/netflix/iep/aws2/AwsModuleTest.java
+++ b/iep-module-aws2/src/test/java/com/netflix/iep/aws2/AwsModuleTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.aws2;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import software.amazon.awssdk.services.ec2.EC2Client;
+
+@RunWith(JUnit4.class)
+public class AwsModuleTest {
+
+  @Test
+  public void createClient() {
+    Injector injector = Guice.createInjector(new AwsModule());
+    AwsClientFactory factory = injector.getInstance(AwsClientFactory.class);
+    EC2Client client = factory.newInstance(EC2Client.class);
+    Assert.assertNotNull(client);
+  }
+
+  @Test
+  public void createClientUsingProvider() {
+    Module module = new AbstractModule() {
+      @Override protected void configure() {
+      }
+
+      @Provides
+      private EC2Client providesEC2(AwsClientFactory factory) {
+        return factory.newInstance(EC2Client.class);
+      }
+    };
+    Injector injector = Guice.createInjector(module, new AwsModule());
+    EC2Client client = injector.getInstance(EC2Client.class);
+    Assert.assertNotNull(client);
+  }
+}

--- a/iep-module-aws2/src/test/java/com/netflix/iep/aws2/PaginationTest.java
+++ b/iep-module-aws2/src/test/java/com/netflix/iep/aws2/PaginationTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.aws2;
+
+import io.reactivex.Flowable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.services.autoscaling.model.DescribeAutoScalingGroupsRequest;
+import software.amazon.awssdk.services.autoscaling.model.DescribeAutoScalingGroupsResponse;
+import software.amazon.awssdk.services.autoscaling.model.DescribeLoadBalancersRequest;
+import software.amazon.awssdk.services.autoscaling.model.DescribeLoadBalancersResponse;
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsResponse;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataResponse;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsResponse;
+import software.amazon.awssdk.services.emr.model.ListClustersRequest;
+import software.amazon.awssdk.services.emr.model.ListClustersResponse;
+import software.amazon.awssdk.services.route53.model.ListHostedZonesRequest;
+import software.amazon.awssdk.services.route53.model.ListHostedZonesResponse;
+import software.amazon.awssdk.services.route53.model.ListResourceRecordSetsRequest;
+import software.amazon.awssdk.services.route53.model.ListResourceRecordSetsResponse;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+@RunWith(JUnit4.class)
+public class PaginationTest {
+
+  private SortedSet<String> newPageSet(int n) {
+    SortedSet<String> pages = new TreeSet<>();
+    for (int i = 0; i < n; ++i) {
+      pages.add(String.format("%05d", i));
+    }
+    return pages;
+  }
+
+  private void autoscalingN(int n) throws Exception {
+    SortedSet<String> pages = newPageSet(n);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<DescribeAutoScalingGroupsRequest, DescribeAutoScalingGroupsResponse> f = r -> {
+      if (r.nextToken() != null) {
+        Assert.assertEquals(reqIt.next(), r.nextToken());
+      }
+      return DescribeAutoScalingGroupsResponse.builder()
+          .nextToken(resIt.hasNext() ? resIt.next() : null)
+          .build();
+    };
+
+    Publisher<DescribeAutoScalingGroupsResponse> publisher =
+        Pagination.createPublisher(DescribeAutoScalingGroupsRequest.builder().build(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.nextToken() != null)
+        .map(DescribeAutoScalingGroupsResponse::nextToken)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void autoscaling() throws Exception {
+    autoscalingN(5);
+  }
+
+  @Test
+  public void autoscalingNoStackOverflow() throws Exception {
+    autoscalingN(10000);
+  }
+
+  @Test
+  public void cloudwatch() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<ListMetricsRequest, ListMetricsResponse> f = r -> {
+      if (r.nextToken() != null) {
+        Assert.assertEquals(reqIt.next(), r.nextToken());
+      }
+      return ListMetricsResponse.builder()
+          .nextToken(resIt.hasNext() ? resIt.next() : null)
+          .build();
+    };
+
+    Publisher<ListMetricsResponse> publisher =
+        Pagination.createPublisher(ListMetricsRequest.builder().build(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.nextToken() != null)
+        .map(ListMetricsResponse::nextToken)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void dynamoDB() throws Exception {
+    Map<String, AttributeValue> nextPage = new HashMap<>();
+    nextPage.put("abc", AttributeValue.builder().build());
+    Map<String, AttributeValue> donePage = new HashMap<>();
+
+    Function<ScanRequest, ScanResponse> f = r -> {
+      if (r.exclusiveStartKey() != null) {
+        Assert.assertTrue(r.exclusiveStartKey().containsKey("abc"));
+      }
+      return ScanResponse.builder()
+          .lastEvaluatedKey((r.exclusiveStartKey() == null) ? nextPage : donePage)
+          .build();
+    };
+
+    Publisher<ScanResponse> publisher = Pagination.createPublisher(ScanRequest.builder().build(), f);
+    Iterable<ScanResponse> iter = Flowable.fromPublisher(publisher)
+        .blockingIterable();
+
+    int count = 0;
+    for (ScanResponse r : iter) {
+      ++count;
+    }
+
+    Assert.assertEquals(2, count);
+  }
+
+  @Test
+  public void cloudwatchPut() throws Exception {
+    final AtomicInteger n = new AtomicInteger();
+    Function<PutMetricDataRequest, PutMetricDataResponse> f = r -> {
+      if (n.getAndIncrement() > 0) {
+        Assert.fail("non-paginated API called more than once");
+      }
+      return PutMetricDataResponse.builder().build();
+    };
+
+    Publisher<PutMetricDataResponse> publisher =
+        Pagination.createPublisher(PutMetricDataRequest.builder().build(), f);
+    Iterable<PutMetricDataResponse> iter = Flowable.fromPublisher(publisher).blockingIterable();
+
+    int count = 0;
+    for (PutMetricDataResponse r : iter) {
+      ++count;
+    }
+
+    Assert.assertEquals(1, count);
+  }
+
+  @Test
+  public void ec2() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<DescribeInstancesRequest, DescribeInstancesResponse> f = r -> {
+      if (r.nextToken() != null) {
+        Assert.assertEquals(reqIt.next(), r.nextToken());
+      }
+      return DescribeInstancesResponse.builder()
+          .nextToken(resIt.hasNext() ? resIt.next() : null)
+          .build();
+    };
+
+    Publisher<DescribeInstancesResponse> publisher =
+        Pagination.createPublisher(DescribeInstancesRequest.builder().build(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.nextToken() != null)
+        .map(DescribeInstancesResponse::nextToken)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void elb() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<DescribeLoadBalancersRequest, DescribeLoadBalancersResponse> f = r -> {
+      if (r.nextToken() != null) {
+        Assert.assertEquals(reqIt.next(), r.nextToken());
+      }
+      return DescribeLoadBalancersResponse.builder()
+          .nextToken(resIt.hasNext() ? resIt.next() : null)
+          .build();
+    };
+
+    Publisher<DescribeLoadBalancersResponse> publisher =
+        Pagination.createPublisher(DescribeLoadBalancersRequest.builder().build(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.nextToken() != null)
+        .map(DescribeLoadBalancersResponse::nextToken)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void elbv2() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<DescribeTargetGroupsRequest, DescribeTargetGroupsResponse> f = r -> {
+      if (r.marker() != null) {
+        Assert.assertEquals(reqIt.next(), r.marker());
+      }
+      return DescribeTargetGroupsResponse.builder()
+          .nextMarker(resIt.hasNext() ? resIt.next() : null)
+          .build();
+    };
+
+    Publisher<DescribeTargetGroupsResponse> publisher =
+        Pagination.createPublisher(DescribeTargetGroupsRequest.builder().build(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.nextMarker() != null)
+        .map(DescribeTargetGroupsResponse::nextMarker)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void emr() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<ListClustersRequest, ListClustersResponse> f = r -> {
+      if (r.marker() != null) {
+        Assert.assertEquals(reqIt.next(), r.marker());
+      }
+      return ListClustersResponse.builder()
+          .marker(resIt.hasNext() ? resIt.next() : null)
+          .build();
+    };
+
+    Publisher<ListClustersResponse> publisher =
+        Pagination.createPublisher(ListClustersRequest.builder().build(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.marker() != null)
+        .map(ListClustersResponse::marker)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void route53HostedZones() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<ListHostedZonesRequest, ListHostedZonesResponse> f = r -> {
+      if (r.marker() != null) {
+        Assert.assertEquals(reqIt.next(), r.marker());
+      }
+      return ListHostedZonesResponse.builder()
+          .nextMarker(resIt.hasNext() ? resIt.next() : null)
+          .build();
+    };
+
+    Publisher<ListHostedZonesResponse> publisher =
+        Pagination.createPublisher(ListHostedZonesRequest.builder().build(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.nextMarker() != null)
+        .map(ListHostedZonesResponse::nextMarker)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s);
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+  @Test
+  public void route53ResourceRecordSets() throws Exception {
+    SortedSet<String> pages = newPageSet(5);
+    final Iterator<String> reqIt = pages.iterator();
+    final Iterator<String> resIt = pages.iterator();
+    Function<ListResourceRecordSetsRequest, ListResourceRecordSetsResponse> f = r -> {
+      if (r.startRecordName() != null) {
+        String expected = reqIt.next();
+        Assert.assertEquals(expected + "-id", r.startRecordIdentifier());
+        Assert.assertEquals(expected + "-name", r.startRecordName());
+        Assert.assertEquals(expected + "-type", r.startRecordType());
+      }
+
+      String next = resIt.hasNext() ? resIt.next() : null;
+      return ListResourceRecordSetsResponse.builder()
+          .nextRecordIdentifier((next != null) ? next + "-id" : null)
+          .nextRecordName((next != null) ? next + "-name" : null)
+          .nextRecordType((next != null) ? next + "-type" : null)
+          .build();
+    };
+
+    Publisher<ListResourceRecordSetsResponse> publisher =
+        Pagination.createPublisher(ListResourceRecordSetsRequest.builder().build(), f);
+    Iterable<String> iter = Flowable.fromPublisher(publisher)
+        .filter(r -> r.nextRecordName() != null)
+        .map(ListResourceRecordSetsResponse::nextRecordName)
+        .blockingIterable();
+
+    SortedSet<String> results = new TreeSet<>();
+    for (String s : iter) {
+      results.add(s.substring(0, 5));
+    }
+
+    Assert.assertEquals(pages, results);
+    Assert.assertFalse(reqIt.hasNext());
+  }
+
+}

--- a/iep-module-aws2/src/test/resources/aws-client-factory.conf
+++ b/iep-module-aws2/src/test/resources/aws-client-factory.conf
@@ -1,0 +1,81 @@
+
+netflix.iep.aws {
+
+  default {
+    client {
+      user-agent-prefix = "abc"
+      user-agent-suffix = "xyz"
+      use-gzip = true
+    }
+  }
+
+  // Override ignore all root level settings
+  ec2-test {
+    client {
+      use-gzip = false
+    }
+
+    credentials {
+      role-arn = "arn:aws:iam::1234567890:role/IepTest"
+      role-session-name = "iep"
+    }
+  }
+
+  // Inherit defaults, but override some settings
+  ec2-test-default = ${netflix.iep.aws.default} {
+    client {
+      use-gzip = false
+    }
+  }
+
+  boolean-true {
+    client {
+      use-reaper = true
+      use-tcp-keep-alive = true
+      use-gzip = true
+      use-throttle-retries = true
+    }
+  }
+
+  boolean-false {
+    client {
+      use-reaper = false
+      use-tcp-keep-alive = false
+      use-gzip = false
+      use-throttle-retries = false
+    }
+  }
+
+  timeouts {
+    client {
+      socket-timeout = 42s
+      connection-timeout = 51s
+      client-execution-timeout = 13s
+    }
+  }
+
+  ttl {
+    client {
+      connection-ttl = 42s
+      connection-max-idle = 51s
+    }
+  }
+
+  integers {
+    client {
+      max-connections = 27
+      max-error-retry = 3
+    }
+  }
+
+  proxy {
+    client {
+      proxy-port = 12345
+      proxy-host = "host"
+      proxy-domain = "domain"
+      proxy-workstation = "workstation"
+      proxy-username = "username"
+      proxy-password = "password"
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
   object Versions {
     val archaius   = "2.2.2"
     val aws        = "1.11.172"
+    val aws2       = "2.0.0-preview-2"
     val eureka     = "1.7.0"
     val guice      = "4.1.0"
     val jackson    = "2.8.7"
@@ -33,6 +34,17 @@ object Dependencies {
   val awsRoute53       = "com.amazonaws" % "aws-java-sdk-route53" % aws
   val awsSES           = "com.amazonaws" % "aws-java-sdk-ses" % aws
   val awsSTS           = "com.amazonaws" % "aws-java-sdk-sts" % aws
+  val aws2AutoScaling  = "software.amazon.awssdk" % "autoscaling" % aws2
+  val aws2Core         = "software.amazon.awssdk" % "core" % aws2
+  val aws2CloudWatch   = "software.amazon.awssdk" % "cloudwatch" % aws2
+  val aws2DynamoDB     = "software.amazon.awssdk" % "dynamodb" % aws2
+  val aws2EC2          = "software.amazon.awssdk" % "ec2" % aws2
+  val aws2ELB          = "software.amazon.awssdk" % "elasticloadbalancing" % aws2
+  val aws2ELBv2        = "software.amazon.awssdk" % "elasticloadbalancingv2" % aws2
+  val aws2EMR          = "software.amazon.awssdk" % "emr" % aws2
+  val aws2Route53      = "software.amazon.awssdk" % "route53" % aws2
+  val aws2SES          = "software.amazon.awssdk" % "ses" % aws2
+  val aws2STS          = "software.amazon.awssdk" % "sts" % aws2
   val equalsVerifier   = "nl.jqno.equalsverifier" % "equalsverifier" % "2.3.1"
   val eurekaClient     = "com.netflix.eureka" % "eureka-client" % eureka
   val guiceAssist      = "com.google.inject.extensions" % "guice-assistedinject" % guice


### PR DESCRIPTION
Provides a module that works with the 2.x SDK. This is
experimental until the 2.x SDK is released and out of
developer preview mode. For now it is purely for early
adopters at Netflix to try out and provide feedback.

Note, jdk9 build is disabled until there is a fix of
either jackson 2.9.1 or in jdk9 itself for manifest
files that contain backticks. See:

https://bugs.openjdk.java.net/browse/JDK-8186334