### PR TITLE
fix module name for aws2 service file

### DIFF
--- a/iep-module-aws2/src/main/resources/META-INF/services/com.google.inject.Module
+++ b/iep-module-aws2/src/main/resources/META-INF/services/com.google.inject.Module
@@ -1,1 +1,1 @@
-com.netflix.iep.aws.AwsModule
+com.netflix.iep.aws2.AwsModule


### PR DESCRIPTION
It was referring to the name for the aws 1.x module.