### PR TITLE
spectator 0.58.0

### DIFF
--- a/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SpectatorEndpointTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SpectatorEndpointTest.java
@@ -22,8 +22,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 
 @RunWith(JUnit4.class)
@@ -171,7 +174,13 @@ public class SpectatorEndpointTest {
     List<SpectatorEndpoint.CounterInfo> datapoints = get("name,counter,:re,a,1,:eq,a,2,:eq,:or,:and");
     Assert.assertEquals(2, datapoints.size());
     Assert.assertEquals(3, datapoints.get(0).getTags().size());
-    Assert.assertEquals(42, datapoints.get(0).getCount());
+    Set<Long> actual = datapoints.stream()
+        .map(SpectatorEndpoint.CounterInfo::getCount)
+        .collect(Collectors.toSet());
+    Set<Long> expected = new HashSet<>();
+    expected.add(42L);
+    expected.add(1L);
+    Assert.assertEquals(expected, actual);
   }
 
   @Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     val rxscala    = "0.26.5"
     val scala      = "2.12.3"
     val slf4j      = "1.7.25"
-    val spectator  = "0.57.1"
+    val spectator  = "0.58.0"
   }
 
   import Versions._


### PR DESCRIPTION
Support for aws-java-sdk 2.