### PR TITLE
make it easier to work with multiple accounts

### DIFF
--- a/iep-module-aws/README.md
+++ b/iep-module-aws/README.md
@@ -73,6 +73,43 @@ Injector injector = Guice.createInjector(module, new AwsModule());
 AmazonEC2 dflt = factory.newInstance(AmazonEC2.class);
 ```
 
+### Multi-Account Usage
+
+When building an application that needs to communicate with many accounts, the factory can be
+used to assume role into a specified account. Use a place holder in the role-arn setting:
+
+```hocon
+netflix.iep.aws {
+  default {
+    credentials {
+      // The account placeholder will get replaced by the requested account id
+      role-arn = "arn:aws:iam::{account}:role/IepTest"
+      role-session-name = "foo"
+    }
+  }
+}
+```
+
+Then when creating a new client pass in the account id, for example:
+
+```java
+AwsClientFactory factory = injector.getInstance(AwsClientFactory.class);
+AmazonEC2 client1 = factory.newInstance(AmazonEC2.class, "12345");
+AmazonEC2 client2 = factory.newInstance(AmazonEC2.class, "54321");
+```
+
+The `newInstance` call will always create a new instance of the client. To reuse a shared client
+for a given account use `getInstance`:
+
+```java
+AwsClientFactory factory = injector.getInstance(AwsClientFactory.class);
+AmazonEC2 client1 = factory.getInstance(AmazonEC2.class, "12345");
+AmazonEC2 client2 = factory.getInstance(AmazonEC2.class, "54321");
+
+// This will be the same instance as client1
+AmazonEC2 client3 = factory.getInstance(AmazonEC2.class, "12345");
+```
+
 ## Gradle
 
 ```

--- a/iep-module-aws/src/test/resources/aws-client-factory.conf
+++ b/iep-module-aws/src/test/resources/aws-client-factory.conf
@@ -78,4 +78,12 @@ netflix.iep.aws {
       proxy-password = "password"
     }
   }
+
+  // Test account substitution
+  ec2-account {
+    credentials {
+      role-arn = "arn:aws:iam::{account}:role/IepTest"
+      role-session-name = "iep"
+    }
+  }
 }


### PR DESCRIPTION
There are two changes to make communicating with multiple
accounts from a single app easier:

1. The `newInstance` methods now have variants that take
   an explicit account id. If the role-arn setting has an
   account placeholder, then the explicit account id will
   get used. Prior to this you would have to use separate
   named blocks for each account which required a lot of
   boilerplate.
2. Added `getInstance` methods that can be used to fetch
   a common shared instance of a given client. With a lot
   of the multi-client code something has to keep track
   of the clients for each account. For simple uses they
   can now just call `getInstance` on the factory.