### PR TITLE
add ConfigManager utility with iep loading logic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -206,6 +206,7 @@ lazy val `iep-module-userservice` = project
 lazy val `iep-nflxenv` = project
   .configure(BuildSettings.profile)
   .settings(libraryDependencies ++= Seq(
+    Dependencies.slf4jApi,
     Dependencies.typesafeConfig
   ))
 

--- a/iep-nflxenv/src/main/java/com/netflix/iep/config/ConfigManager.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/config/ConfigManager.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.config;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+/**
+ * Helper for loading the typesafe config instance. In most cases for apps using the IEP
+ * libraries this should be used instead of {@link ConfigFactory}. It supports loading
+ * additional configuration files based on the context via the {@code netflix.iep.include}
+ * setting.
+ */
+public final class ConfigManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigManager.class);
+
+  private static final Config CONFIG = load();
+
+  /** Get a cached copy of the config loaded from the default class loader. */
+  public static Config get() {
+    return CONFIG;
+  }
+
+  /** Load config using the default class loader. */
+  public static Config load() {
+    return load(pickClassLoader());
+  }
+
+  /** Load config using the specified class loader. */
+  public static Config load(ClassLoader classLoader) {
+    final String prop = "netflix.iep.env.account-type";
+    final Config baseConfig = ConfigFactory.load(classLoader);
+    final String envConfigName = "iep-" + baseConfig.getString(prop) + ".conf";
+    final Config envConfig = loadConfigByName(classLoader, envConfigName);
+    return loadIncludes(classLoader, envConfig.withFallback(baseConfig).resolve());
+  }
+
+  private static ClassLoader pickClassLoader() {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    if (cl == null) {
+      LOGGER.warn(
+          "Thread.currentThread().getContextClassLoader() is null, using loader for {}",
+          ConfigManager.class.getName());
+      return ConfigManager.class.getClassLoader();
+    } else {
+      return cl;
+    }
+  }
+
+  private static Config loadConfigByName(ClassLoader classLoader, String name) {
+    LOGGER.debug("loading config {}", name);
+    if (name.startsWith("file:")) {
+      File f = new File(name.substring("file:".length()));
+      return ConfigFactory.parseFile(f);
+    } else {
+      return ConfigFactory.parseResources(classLoader, name);
+    }
+  }
+
+  private static Config loadIncludes(ClassLoader classLoader, Config baseConfig) {
+    final String prop = "netflix.iep.include";
+    Config acc = baseConfig;
+    for (String name : baseConfig.getStringList(prop)) {
+      Config cfg = loadConfigByName(classLoader, name);
+      acc = cfg.withFallback(acc);
+    }
+    return acc.resolve();
+  }
+}

--- a/iep-nflxenv/src/test/java/com/netflix/iep/config/ConfigManagerTest.java
+++ b/iep-nflxenv/src/test/java/com/netflix/iep/config/ConfigManagerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.config;
+
+import com.typesafe.config.Config;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ConfigManagerTest {
+
+  @Test
+  public void accountConfig() {
+    Assert.assertTrue(ConfigManager.get().getBoolean("iep.account-config-loaded"));
+  }
+
+  @Test
+  public void loadFromFile() {
+    Assert.assertTrue(ConfigManager.get().getBoolean("iep.file-include-loaded"));
+  }
+
+  @Test
+  public void loadFromClasspath() {
+    Assert.assertTrue(ConfigManager.get().getBoolean("iep.classpath-include-loaded"));
+  }
+
+  @Test
+  public void includeOverrides() {
+    Assert.assertEquals("classpath", ConfigManager.get().getString("iep.value"));
+  }
+
+  @Test
+  public void includeDoesNotOverrideSubstitutions() {
+    Assert.assertEquals("reference", ConfigManager.get().getString("iep.substitute"));
+  }
+
+  @Test
+  public void nullContextClassLoader() {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(null);
+      Config config = ConfigManager.load();
+      Assert.assertEquals("foo", config.getString("netflix.iep.env.account-type"));
+    } finally {
+      Thread.currentThread().setContextClassLoader(cl);
+    }
+  }
+}

--- a/iep-nflxenv/src/test/resources/application.conf
+++ b/iep-nflxenv/src/test/resources/application.conf
@@ -1,0 +1,17 @@
+
+
+netflix.iep.env.account-type = foo
+
+netflix.iep.include = ${?netflix.iep.include} [
+  // Assumes working directory is either root of project, this sub-project, or
+  // iep/.idea/modules/
+  "file:src/test/resources/file-include.conf",
+  "file:iep-nflxenv/src/test/resources/file-include.conf",
+  "file:../../iep-nflxenv/src/test/resources/file-include.conf",
+
+  "classpath-include.conf"
+]
+
+// This is set in the reference conf, the application conf, and the classpath include.
+// The classpath include should win
+iep.value = "application"

--- a/iep-nflxenv/src/test/resources/classpath-include.conf
+++ b/iep-nflxenv/src/test/resources/classpath-include.conf
@@ -1,0 +1,4 @@
+
+iep.classpath-include-loaded = true
+
+iep.value = "classpath"

--- a/iep-nflxenv/src/test/resources/file-include.conf
+++ b/iep-nflxenv/src/test/resources/file-include.conf
@@ -1,0 +1,2 @@
+
+iep.file-include-loaded = true

--- a/iep-nflxenv/src/test/resources/iep-foo.conf
+++ b/iep-nflxenv/src/test/resources/iep-foo.conf
@@ -1,0 +1,2 @@
+
+iep.account-config-loaded = true

--- a/iep-nflxenv/src/test/resources/reference.conf
+++ b/iep-nflxenv/src/test/resources/reference.conf
@@ -1,0 +1,3 @@
+
+iep.value = "reference"
+iep.substitute = ${iep.value}

--- a/iep-platformservice/src/test/java/com/netflix/iep/platformservice/PlatformServiceModuleTest.java
+++ b/iep-platformservice/src/test/java/com/netflix/iep/platformservice/PlatformServiceModuleTest.java
@@ -56,7 +56,7 @@ public class PlatformServiceModuleTest {
   public void loadConfig() {
     PlatformServiceModule m = new PlatformServiceModule();
     com.typesafe.config.Config c = m.providesTypesafeConfig();
-    Assert.assertEquals("main", c.getString("account-specific-prop"));
+    Assert.assertTrue(c.getBoolean("iep.account-config-loaded"));
   }
 
   @Test
@@ -113,6 +113,6 @@ public class PlatformServiceModuleTest {
   public void includesLaterFilesOverride() {
     PlatformServiceModule m = new PlatformServiceModule();
     com.typesafe.config.Config c = m.providesTypesafeConfig();
-    Assert.assertEquals("def:main", c.getString("includes.b"));
+    Assert.assertEquals("def:foo", c.getString("includes.b"));
   }
 }

--- a/iep-platformservice/src/test/resources/application.conf
+++ b/iep-platformservice/src/test/resources/application.conf
@@ -1,8 +1,9 @@
+netflix.iep.env.account-type = foo
 
 // Test property for check to ensure application.conf is loaded as expected
 iep.test.which-config = app
 
-netflix.iep.include = [
+netflix.iep.include = ${?netflix.iep.include} [
   "a.conf",
   "c.conf",
   "c.conf"

--- a/iep-platformservice/src/test/resources/iep-foo.conf
+++ b/iep-platformservice/src/test/resources/iep-foo.conf
@@ -1,0 +1,2 @@
+
+iep.account-config-loaded = true

--- a/iep-platformservice/src/test/resources/iep-main.conf
+++ b/iep-platformservice/src/test/resources/iep-main.conf
@@ -1,2 +1,0 @@
-
-account-specific-prop = ${netflix.iep.env.account-type}


### PR DESCRIPTION
This makes it easier to reuse the loading we are using
for the typesafe config objects and in most cases can
be used as a substitute for `ConfigFactory.load` to make
those use-cases consistent. Unfortunately there are some
places that do not get the injected config and this helps
avoid inconsistencies.