### PR TITLE
update travis to build on jdk10/11-ea

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ matrix:
   include:
   - jdk: oraclejdk8
     env: BINTRAY_PUBLISH=true
-  - jdk: oraclejdk9
+  - jdk: openjdk10
+    env: BINTRAY_PUBLISH=false
+  - jdk: openjdk11
     env: BINTRAY_PUBLISH=false
 scala:
-- 2.12.4
+- 2.12.6
 sudo: false
 script:
 - ./buildViaTravis.sh

--- a/build.sbt
+++ b/build.sbt
@@ -230,6 +230,7 @@ lazy val `iep-rxhttp` = project
   .settings(libraryDependencies ++= Seq(
     Dependencies.archaiusCore,
     Dependencies.eurekaClient,
+    Dependencies.jsr250,
     Dependencies.jzlib,
     Dependencies.rxjava,
     Dependencies.rxnettyCore,
@@ -243,6 +244,7 @@ lazy val `iep-service` = project
   .configure(BuildSettings.profile)
   .settings(libraryDependencies ++= Seq(
     Dependencies.inject,
+    Dependencies.jsr250,
     Dependencies.slf4jApi
   ))
 

--- a/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SystemPropsEndpointTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SystemPropsEndpointTest.java
@@ -37,8 +37,8 @@ public class SystemPropsEndpointTest {
 
   @Test @SuppressWarnings("unchecked")
   public void getProperty() {
+    // jdk10+ have a java.version.date property
     Map<String, String> map = (Map<String, String>) endpoint.get("java.version");
-    Assert.assertEquals(1, map.size());
     Assert.assertEquals(System.getProperty("java.version"), map.get("java.version"));
   }
 


### PR DESCRIPTION
Dropping jdk9 as there is no reason to use it over
jdk10 at this point.