### PR TITLE
use global registry internal to config

### DIFF
--- a/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
+++ b/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
@@ -15,7 +15,6 @@
  */
 package com.netflix.iep.platformservice;
 
-import com.google.inject.Inject;
 import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.netflix.archaius.api.config.PollingStrategy;
@@ -27,8 +26,8 @@ import com.netflix.archaius.typesafe.TypesafeConfig;
 import com.netflix.iep.admin.AdminConfig;
 import com.netflix.iep.admin.guice.AdminModule;
 import com.netflix.iep.config.ConfigManager;
-import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Spectator;
 import com.typesafe.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,9 +61,9 @@ public final class PlatformServiceModule extends ArchaiusModule {
   @Provides
   @Singleton
   @RemoteLayer
-  private com.netflix.archaius.api.Config providesOverrideConfig(OptionalInjections opts, Config cfg)
+  private com.netflix.archaius.api.Config providesOverrideConfig(Config cfg)
       throws Exception {
-    return getDynamicConfig(opts.getRegistry(), cfg);
+    return getDynamicConfig(Spectator.globalRegistry(), cfg);
   }
 
   @Provides
@@ -126,18 +125,5 @@ public final class PlatformServiceModule extends ArchaiusModule {
     return (cfg.getBoolean(propUseDynamic))
       ? new PollingDynamicConfig(getCallback(registry, cfg), getPollingStrategy(cfg))
       : EmptyConfig.INSTANCE;
-  }
-
-  @Singleton
-  private static class OptionalInjections {
-    @Inject(optional = true)
-    Registry registry;
-
-    Registry getRegistry() {
-      if (registry == null) {
-        registry = new DefaultRegistry();
-      }
-      return registry;
-    }
   }
 }

--- a/iep-platformservice/src/test/resources/application.conf
+++ b/iep-platformservice/src/test/resources/application.conf
@@ -1,3 +1,11 @@
+
+netflix.iep.archaius {
+  url = "http://localhost:7101/props"
+  use-dynamic = true
+  sync-init = false
+  polling-interval = 30s
+}
+
 netflix.iep.env.account-type = foo
 
 // Test property for check to ensure application.conf is loaded as expected


### PR DESCRIPTION
If the registry implementation needs to use the config, then
it will create a circular dependency between the config and
the registry instance and fail with:

```
Caused by: java.lang.IllegalStateException: This is a proxy
  used to support circular references. The object we're
  proxying is not constructed yet. Please wait until after
  injection has completed to use this object.
```

To avoid this the config bindings will now use the Spectator
global registry internally. This breaks the cycle and still
allows the remote config loading to report metrics as long
as the registry binding adds itself to the global registry.