### PR TITLE
aws-sdk-java 2.0.0-preview-10

### DIFF
--- a/iep-module-aws2/src/test/java/com/netflix/iep/aws2/AwsClientFactoryTest.java
+++ b/iep-module-aws2/src/test/java/com/netflix/iep/aws2/AwsClientFactoryTest.java
@@ -21,8 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import software.amazon.awssdk.core.auth.AwsCredentialsProvider;
-import software.amazon.awssdk.core.auth.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.services.ec2.EC2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeAddressesRequest;
@@ -125,11 +125,12 @@ public class AwsClientFactoryTest {
     Assert.assertEquals(false, settings.gzipEnabled());
   }
 
-  @Test
+  // TODO: timeouts are no longer settable on the override configuration
+  /*@Test
   public void settingsTimeout() {
     AwsClientFactory factory = new AwsClientFactory(config);
     ClientOverrideConfiguration settings = factory.createClientConfig("timeouts");
     Assert.assertEquals(Duration.ofMillis(42000), settings.httpRequestTimeout());
     Assert.assertEquals(Duration.ofMillis(13000), settings.totalExecutionTimeout());
-  }
+  }*/
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object Versions {
     val archaius   = "2.3.2"
     val aws        = "1.11.339"
-    val aws2       = "2.0.0-preview-9"
+    val aws2       = "2.0.0-preview-10"
     val eureka     = "1.9.2"
     val guice      = "4.1.0"
     val jackson    = "2.9.6"


### PR DESCRIPTION
A few package name changes and the timeout settings
have changed. Will look at that later when investigating
how to integrate basic IPC metrics.