### PR TITLE
include attachment name in Content-Type header

### DIFF
--- a/iep-ses/src/main/java/com/netflix/iep/ses/Attachment.java
+++ b/iep-ses/src/main/java/com/netflix/iep/ses/Attachment.java
@@ -85,7 +85,7 @@ public class Attachment {
 
   @Override public String toString() {
     return new StringBuilder()
-        .append(EmailHeader.contentType(contentType).toString())
+        .append(EmailHeader.contentType(contentType, name).toString())
         .append(EmailHeader.contentTransferEncoding("base64").toString())
         .append(EmailHeader.contentDisposition(disposition).toString())
         .append(EmailHeader.contentID(name).toString())

--- a/iep-ses/src/main/java/com/netflix/iep/ses/EmailHeader.java
+++ b/iep-ses/src/main/java/com/netflix/iep/ses/EmailHeader.java
@@ -37,6 +37,11 @@ class EmailHeader {
     return new EmailHeader("Content-Type", type);
   }
 
+  /** Content type header for a part of the message. */
+  static EmailHeader contentType(String type, String name) {
+    return new EmailHeader("Content-Type", type + "; name=\"" + name + "\"");
+  }
+
   /**
    * Disposition of the message. This is typically used to indicate if something is an
    * attachment or indended to be viewed inline.

--- a/iep-ses/src/test/resources/htmlWithInlineImage
+++ b/iep-ses/src/test/resources/htmlWithInlineImage
@@ -12,7 +12,7 @@ Content-Transfer-Encoding: base64
 PGh0bWw+PGJvZHk+PGgxPkFsZXJ0ITwvaDE+PHA+PGltZyBzcmM9ImNpZDpkZXMtZXhhbXBsZS5w
 bmciIC8+PC9wPjwvYm9keT48L2h0bWw+
 --331239ab-8a31-4cc6-84d6-5557f96ebc3a
-Content-Type: image/png
+Content-Type: image/png; name="des-example.png"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment
 Content-ID: <des-example.png>


### PR DESCRIPTION
This is used by GMail and possibly other mail clients to
show the user the name of an attachment. Before this change
it would show as `noname`.

/cc @ruchirj 