### PR TITLE
improve support for using sending authorization

### DIFF
--- a/iep-ses/README.md
+++ b/iep-ses/README.md
@@ -1,11 +1,12 @@
 
 ## Description
 
-Builder to make it easier to construct
-[SendRawEmailRequest](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/simpleemail/model/SendRawEmailRequest.html)
-objects for the common case of an HTML email message with a handful of attachments.
-For example, an alert email that provides the [Atlas graph](https://github.com/Netflix/atlas/wiki)
-indicating why the alert triggered as an image attachment.
+Builder to make it easier to construct [SendRawEmailRequest] objects for the common case of
+an HTML email message with a handful of attachments. For example, an alert email that provides
+the [Atlas graph] indicating why the alert triggered as an image attachment.
+
+[SendRawEmailRequest]: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/simpleemail/model/SendRawEmailRequest.html
+[Atlas graph]: https://github.com/Netflix/atlas/wiki
 
 Sample usage:
 
@@ -13,13 +14,50 @@ Sample usage:
 AmazonSimpleEmailService client = new AmazonSimpleEmailServiceClient(
   new DefaultAWSCredentialsProviderChain());
 client.sendRawEmail(new EmailRequestBuilder()
-  .withSource("bob@example.com")
+  .withFromAddress("bob@example.com")
   .withToAddresses("andrew@example.com")
   .withSubject("Test message")
   .withHtmlBody("<html><body><h1>Alert!</h1><p><img src=\"cid:graph.png\" /></p></body></html>")
   .addAttachment(Attachment.fromResource("image/png", "graph.png"))
   .build());
 ```
+
+## Sending Authorization
+
+To use with [sending authorization] there are two options. The first is to set the from address
+and from identity ARN using the `EmailRequestBuilder`:
+
+```java
+AmazonSimpleEmailService client = new AmazonSimpleEmailServiceClient(
+  new DefaultAWSCredentialsProviderChain());
+client.sendRawEmail(new EmailRequestBuilder()
+  .withFromArn("arn:aws:ses:us-east-1:123456789012:identity/example.com")
+  .withFromAddress("bob@example.com")
+  .withToAddresses("andrew@example.com")
+  .withSubject("Test")
+  .withTextBody("Body of the message.")
+  .build());
+```
+
+The other is to omit the from address when using `EmailRequestBuilder` and specify the source
+and source arn on the `SendRawEmailRequest` object:
+
+```java
+AmazonSimpleEmailService client = new AmazonSimpleEmailServiceClient(
+  new DefaultAWSCredentialsProviderChain());
+RawMessage msg = new EmailRequestBuilder()
+  .withToAddresses("andrew@example.com")
+  .withSubject("Test")
+  .withTextBody("Body of the message.")
+  .toRawMessage();
+SendRawEmailRequest request = new SendRawEmailRequest()
+  .withSourceArn("arn:aws:ses:us-east-1:123456789012:identity/example.com")
+  .withSource("bob@example.com")
+  .withRawMessage(msg);
+client.sendRawEmail(request);
+```
+
+[sending authorization]: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html
 
 ## Gradle
 

--- a/iep-ses/src/main/java/com/netflix/iep/ses/EmailHeader.java
+++ b/iep-ses/src/main/java/com/netflix/iep/ses/EmailHeader.java
@@ -73,6 +73,11 @@ class EmailHeader {
     return new EmailHeader("From", address);
   }
 
+  /** Identity associated with the sending authorization policy. */
+  static EmailHeader fromArn(String arn) {
+    return new EmailHeader("X-SES-FROM-ARN", arn);
+  }
+
   /** Addresses of the users who should receive the message. */
   static EmailHeader to(String addresses) {
     return new EmailHeader("To", EncodingUtils.wrap(addresses, "To: ".length(), 78));

--- a/iep-ses/src/test/resources/sendingAuthorizationFromArn
+++ b/iep-ses/src/test/resources/sendingAuthorizationFromArn
@@ -1,0 +1,14 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+  boundary="331239ab-8a31-4cc6-84d6-5557f96ebc3a"
+From: bob@example.com
+To: andrew@example.com
+Subject: =?UTF-8?B?VGVzdCBtZXNzYWdl?=
+X-SES-FROM-ARN: arn:aws:ses:us-east-1:123456789012:identity/example.com
+
+--331239ab-8a31-4cc6-84d6-5557f96ebc3a
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: base64
+
+Qm9keSBvZiB0aGUgZW1haWwgbWVzc2FnZS4=
+--331239ab-8a31-4cc6-84d6-5557f96ebc3a--

--- a/iep-ses/src/test/resources/sendingAuthorizationRequestParams
+++ b/iep-ses/src/test/resources/sendingAuthorizationRequestParams
@@ -1,0 +1,12 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+  boundary="331239ab-8a31-4cc6-84d6-5557f96ebc3a"
+To: andrew@example.com
+Subject: =?UTF-8?B?VGVzdCBtZXNzYWdl?=
+
+--331239ab-8a31-4cc6-84d6-5557f96ebc3a
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: base64
+
+Qm9keSBvZiB0aGUgZW1haWwgbWVzc2FnZS4=
+--331239ab-8a31-4cc6-84d6-5557f96ebc3a--


### PR DESCRIPTION
When using SES sending authorization and SendRawEmail, the
SourceArn will only work if the From address header is not
specified in the raw message. This is not clear from reading
the AWS documentation.

This change updates the helper to allow the FromArn to be
specified as part of the raw message which does work when
a from header is included. It also allows the from header
to be omitted now so that it can be included by calling
withSource on the SendRawEmailRequest object.

The readme has also been updated to cover the use with sending
authorization.