### PR TITLE
update iep-ses to work with aws-sdk-java-v2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -252,5 +252,6 @@ lazy val `iep-ses` = project
   .configure(BuildSettings.profile)
   .settings(libraryDependencies ++= Seq(
     Dependencies.awsCore,
-    Dependencies.awsSES
+    Dependencies.awsSES,
+    Dependencies.aws2SES % "test"
   ))

--- a/iep-ses/README.md
+++ b/iep-ses/README.md
@@ -8,18 +8,36 @@ the [Atlas graph] indicating why the alert triggered as an image attachment.
 [SendRawEmailRequest]: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/simpleemail/model/SendRawEmailRequest.html
 [Atlas graph]: https://github.com/Netflix/atlas/wiki
 
-Sample usage:
+## Gradle
+
+```
+compile "com.netflix.iep:iep-ses:${version_iep}"
+```
+
+## Basic Usage
 
 ```java
-AmazonSimpleEmailService client = new AmazonSimpleEmailServiceClient(
-  new DefaultAWSCredentialsProviderChain());
-client.sendRawEmail(new EmailRequestBuilder()
+// Construct the MIME encoded request
+ByteBuffer data = new EmailRequestBuilder()
   .withFromAddress("bob@example.com")
   .withToAddresses("andrew@example.com")
   .withSubject("Test message")
   .withHtmlBody("<html><body><h1>Alert!</h1><p><img src=\"cid:graph.png\" /></p></body></html>")
   .addAttachment(Attachment.fromResource("image/png", "graph.png"))
-  .build());
+  .toByteBuffer();
+
+// If using AWS SDK for Java V1
+AmazonSimpleEmailService client = new AmazonSimpleEmailServiceClient(
+  new DefaultAWSCredentialsProviderChain());
+RawMessage message = new RawMessage().withData(data);
+client.sendRawEmail(new SendRawEmailRequest().withRawMessage(message));
+
+// If using AWS SDK for Java V2
+SesClient client = SesClient.create();
+SendRawEmailRequest request = SendRawEmailRequest.builder()
+  .rawMessage(RawMessage.builder().data(SdkBytes.fromByteBuffer(data)).build())
+  .build();
+client.sendRawEmail(request);
 ```
 
 ## Sending Authorization
@@ -28,39 +46,46 @@ To use with [sending authorization] there are two options. The first is to set t
 and from identity ARN using the `EmailRequestBuilder`:
 
 ```java
-AmazonSimpleEmailService client = new AmazonSimpleEmailServiceClient(
-  new DefaultAWSCredentialsProviderChain());
-client.sendRawEmail(new EmailRequestBuilder()
+// Construct the MIME encoded request
+ByteBuffer data = new EmailRequestBuilder()
   .withFromArn("arn:aws:ses:us-east-1:123456789012:identity/example.com")
   .withFromAddress("bob@example.com")
   .withToAddresses("andrew@example.com")
   .withSubject("Test")
   .withTextBody("Body of the message.")
-  .build());
+  .toByteBuffer();
+
+// Send as in basic usage example
 ```
 
 The other is to omit the from address when using `EmailRequestBuilder` and specify the source
 and source arn on the `SendRawEmailRequest` object:
 
 ```java
-AmazonSimpleEmailService client = new AmazonSimpleEmailServiceClient(
-  new DefaultAWSCredentialsProviderChain());
-RawMessage msg = new EmailRequestBuilder()
+// Construct the MIME encoded request, do not include from address
+ByteBuffer data = new EmailRequestBuilder()
   .withToAddresses("andrew@example.com")
   .withSubject("Test")
   .withTextBody("Body of the message.")
-  .toRawMessage();
+  .toByteBuffer();
+
+// If using AWS SDK for Java V1
+AmazonSimpleEmailService client = new AmazonSimpleEmailServiceClient(
+  new DefaultAWSCredentialsProviderChain());
 SendRawEmailRequest request = new SendRawEmailRequest()
   .withSourceArn("arn:aws:ses:us-east-1:123456789012:identity/example.com")
   .withSource("bob@example.com")
-  .withRawMessage(msg);
+  .withRawMessage(new RawMessage().withData(data));
+client.sendRawEmail(request);
+
+// If using AWS SDK for Java V2
+SesClient client = SesClient.create();
+SendRawEmailRequest request = SendRawEmailRequest.builder()
+  .sourceArn("arn:aws:ses:us-east-1:123456789012:identity/example.com")
+  .source("bob@example.com")
+  .rawMessage(RawMessage.builder().data(SdkBytes.fromByteBuffer(data)).build())
+  .build();
 client.sendRawEmail(request);
 ```
 
 [sending authorization]: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html
-
-## Gradle
-
-```
-compile "com.netflix.iep:iep-ses:${version_iep}"
-```

--- a/iep-ses/src/test/java/com/netflix/iep/ses/AwsSdk2Test.java
+++ b/iep-ses/src/test/java/com/netflix/iep/ses/AwsSdk2Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.iep.ses;
 
 import org.junit.Assert;

--- a/iep-ses/src/test/java/com/netflix/iep/ses/AwsSdk2Test.java
+++ b/iep-ses/src/test/java/com/netflix/iep/ses/AwsSdk2Test.java
@@ -1,0 +1,26 @@
+package com.netflix.iep.ses;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import software.amazon.awssdk.core.SdkBytes;
+
+@RunWith(JUnit4.class)
+public class AwsSdk2Test {
+
+  @Test
+  public void builderToSdkBytes() throws Exception {
+    EmailRequestBuilder builder = new EmailRequestBuilder()
+        .withFromAddress("alert-do-not-reply@saasmail.netflix.com")
+        .withToAddresses("brharrington@netflix.com")
+        .withSubject("Test message")
+        .withHtmlBody("<html><body><h1>Alert!</h1><p><img src=\"cid:des-example.png\"></p></body></html>")
+        .addAttachment(Attachment.fromResource("image/png", "des-example.png"));
+    SdkBytes buffer = SdkBytes.fromByteBuffer(builder.toByteBuffer());
+    SdkBytes bytes = SdkBytes.fromByteArray(builder.toByteArray());
+    SdkBytes string = SdkBytes.fromUtf8String(builder.toString());
+    Assert.assertEquals(buffer, bytes);
+    Assert.assertEquals(buffer, string);
+  }
+}


### PR DESCRIPTION
Adds helpers to get the `ByteBuffer` directly so it can
be used to construct the `RawMessage` object for either
v1 or v2 of the SDK. It is now fairly straightforward
to use with either version, but there is an explicit
dependency on v1 so it will get pulled in even if the
user is using v2.

Methods that refer to v1 classes have been deprecated so
we can remove the explicit dependency in iep-ses 2.0. At
that point the only version of the AWS libraries in the
classpath will be what the user depends on.