### PR TITLE
fix endless loop for listHostedZones

### DIFF
--- a/iep-module-aws/src/main/java/com/netflix/iep/aws/Pagination.java
+++ b/iep-module-aws/src/main/java/com/netflix/iep/aws/Pagination.java
@@ -205,9 +205,7 @@ public final class Pagination {
         for (Method getter : result.getClass().getMethods()) {
           if (getter.getName().equals(GET_NEXT[i])) {
             Object next = getter.invoke(result);
-            if (!isNullOrEmpty(next)) {
-              hasNext = true;
-            }
+            hasNext = !isNullOrEmpty(next);
             Method setter = request.getClass().getMethod(SET_NEXT[i], getter.getReturnType());
             setter.invoke(request, next);
           }

--- a/iep-module-aws/src/test/java/com/netflix/iep/aws/PaginationTest.java
+++ b/iep-module-aws/src/test/java/com/netflix/iep/aws/PaginationTest.java
@@ -395,7 +395,11 @@ public class PaginationTest {
       if (r.getMarker() != null) {
         Assert.assertEquals(reqIt.next(), r.getMarker());
       }
+      // Hosted zones result has both withMarker and withNextMarker. Set withMarker to
+      // ensure it does not get used for pagination. Last issue is it manifested as an
+      // endless loop because the marker would get used if nextMarker was null.
       return new ListHostedZonesResult()
+          .withMarker("test")
           .withNextMarker(resIt.hasNext() ? resIt.next() : null);
     };
 


### PR DESCRIPTION
This result object has both `withMarker` and `withNextMarker`.
The marker is what was used for the request that generated the
result and should get ignored for pagination. Before, if the
call resulted in multiple pages, the marker would always have
a value for the last page and cause it to indicate that there
was another request. However it was correctly updating the
request with the result of next marker so it would start over
from the beginning.

The test case has been updated to reproduce the issue.