### PR TITLE
add travis build for jdk12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11
     env: BINTRAY_PUBLISH=false
+  - jdk: openjdk12
+    env: BINTRAY_PUBLISH=false
 scala:
 - 2.12.8
 sudo: false


### PR DESCRIPTION
Current goal is to ensure the libraries work on jdk8, jdk11,
and latest.