### PR TITLE
deprecate public classes for old libraries

### DIFF
--- a/iep-config/README.md
+++ b/iep-config/README.md
@@ -1,7 +1,7 @@
 
 ## Description
 
-> :warning: Deprecated. For new work prefer [iep-module-archaius2][a2].
+> :warning: **Deprecated:** For new work prefer [iep-module-archaius2][a2].
 
 [a2]: https://github.com/Netflix/iep/tree/master/iep-module-archaius2
 

--- a/iep-config/src/main/java/com/netflix/iep/config/ConfigFile.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/ConfigFile.java
@@ -48,7 +48,10 @@ import javax.script.ScriptException;
  * Properties can be deleted by setting them to null
  * netflix.atlas.foo=null
  * </pre>
+ *
+ * @deprecated Switch to injecting a Config instance.
  */
+@Deprecated
 public class ConfigFile {
 
   public static boolean checkScope(Map<String,String> vars, String str) {

--- a/iep-config/src/main/java/com/netflix/iep/config/ConfigModule.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/ConfigModule.java
@@ -30,6 +30,10 @@ import com.typesafe.config.Config;
 import javax.inject.Singleton;
 import java.util.Properties;
 
+/**
+ * @deprecated Switch to injecting a Config instance.
+ */
+@Deprecated
 public class ConfigModule extends AbstractModule {
 
   private final String[] propFiles;

--- a/iep-config/src/main/java/com/netflix/iep/config/Configuration.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/Configuration.java
@@ -21,6 +21,10 @@ import java.lang.reflect.Proxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated Switch to injecting a Config instance.
+ */
+@Deprecated
 public final class Configuration {
   private final static Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 

--- a/iep-config/src/main/java/com/netflix/iep/config/DefaultValue.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/DefaultValue.java
@@ -20,6 +20,7 @@ import java.lang.annotation.*;
 /**
  * Indicates a default value that will be used if the property is not explicitly set.
  */
+@Deprecated
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})

--- a/iep-config/src/main/java/com/netflix/iep/config/DynamicNoOpConfigModule.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/DynamicNoOpConfigModule.java
@@ -36,6 +36,10 @@ import javax.inject.Singleton;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * @deprecated Switch to injecting a Config instance.
+ */
+@Deprecated
 public class DynamicNoOpConfigModule extends AbstractModule {
 
   private final String[] propFiles;

--- a/iep-config/src/main/java/com/netflix/iep/config/DynamicPropertiesConfiguration.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/DynamicPropertiesConfiguration.java
@@ -25,6 +25,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 
+/**
+ * @deprecated Switch to injecting a Config instance.
+ */
+@Deprecated
 @Singleton
 public class DynamicPropertiesConfiguration implements AutoCloseable {
 

--- a/iep-config/src/main/java/com/netflix/iep/config/IConfiguration.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/IConfiguration.java
@@ -15,6 +15,10 @@
  */
 package com.netflix.iep.config;
 
+/**
+ * @deprecated Switch to injecting a Config instance.
+ */
+@Deprecated
 public interface IConfiguration {
   String get(String key);
 }

--- a/iep-config/src/main/java/com/netflix/iep/config/ScopedPropertiesLoader.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/ScopedPropertiesLoader.java
@@ -24,6 +24,10 @@ import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated Switch to injecting a Config instance.
+ */
+@Deprecated
 public class ScopedPropertiesLoader {
   private static final Logger LOGGER = LoggerFactory.getLogger(ScopedPropertiesLoader.class);
 

--- a/iep-config/src/main/java/com/netflix/iep/config/Strings.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/Strings.java
@@ -31,6 +31,10 @@ import org.joda.time.format.ISOPeriodFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.PeriodFormatter;
 
+/**
+ * @deprecated Switch to injecting a Config instance.
+ */
+@Deprecated
 public class Strings {
   private Strings() {}
 

--- a/iep-config/src/main/java/com/netflix/iep/config/TestResourceConfiguration.java
+++ b/iep-config/src/main/java/com/netflix/iep/config/TestResourceConfiguration.java
@@ -25,6 +25,10 @@ import com.netflix.archaius.api.Config;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.archaius.config.MapConfig;
 
+/**
+ * @deprecated Switch to injecting a Config instance.
+ */
+@Deprecated
 public class TestResourceConfiguration {
   private TestResourceConfiguration() {}
 

--- a/iep-module-archaius1/README.md
+++ b/iep-module-archaius1/README.md
@@ -1,6 +1,8 @@
 
 ## Description
 
+> :warning: **Deprecated:** move to Archaius 2 or Typesafe Config.
+
 Guice module to configure [archaius1](https://github.com/Netflix/archaius). This module will
 primarily setup the [archaius2-archaius1-bridge](https://github.com/Netflix/archaius/tree/2.x/archaius2-archaius1-bridge)
 so that archaius1 will be delegating to archaius2.

--- a/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius1Module.java
+++ b/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius1Module.java
@@ -29,7 +29,11 @@ import javax.inject.Singleton;
 
 /**
  * Helper for configuring archaius v1.
+ *
+ * @deprecated Move to archaius v2 or to using Typesafe Config directly. Note, Runtime support
+ * for archaius v2 looks to be limited.
  */
+@Deprecated
 public final class Archaius1Module extends AbstractModule {
 
   @Override protected void configure() {

--- a/iep-rxhttp/README.md
+++ b/iep-rxhttp/README.md
@@ -1,6 +1,11 @@
 
 ## Description
 
+> :warning: **Deprecated:** This library depends on RxNetty which is unsupported and
+> RxJava 1.x which reached [end of life] on March 31, 2018. Move to a supported HTTP client.
+
+[end of life]: https://github.com/ReactiveX/RxJava/releases/tag/v1.3.8
+
 Simple wrapper on top of [RxNetty](https://github.com/ReactiveX/RxNetty) that provides
 integration with [Eureka](https://github.com/Netflix/eureka/) and
 [Archaius2](https://github.com/Netflix/archaius/tree/2.x).

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/BasicServerRegistry.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/BasicServerRegistry.java
@@ -23,7 +23,11 @@ import java.util.Set;
 
 /**
  * Registry with a fixed set of servers specified at creation.
+ *
+ * @deprecated This library depends on RxNetty which is unsupported and RxJava 1.x which reached
+ * end of life on March 31, 2018. Move to a supported HTTP client.
  */
+@Deprecated
 public class BasicServerRegistry implements ServerRegistry {
 
   private final Map<String, List<Server>> serversByVip;

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/ByteBufs.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/ByteBufs.java
@@ -32,7 +32,11 @@ import java.io.UnsupportedEncodingException;
 
 /**
  * Helper operations for working with {@code Observable<ByteBuf>} objects.
+ *
+ * @deprecated This library depends on RxNetty which is unsupported and RxJava 1.x which reached
+ * end of life on March 31, 2018. Move to a supported HTTP client.
  */
+@Deprecated
 public final class ByteBufs {
 
   private ByteBufs() {

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/EurekaServerRegistry.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/EurekaServerRegistry.java
@@ -29,7 +29,11 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Registry that gets the server list from eureka. Servers that have a status of UP and are
  * registered with the requested vip will get used.
+ *
+ * @deprecated This library depends on RxNetty which is unsupported and RxJava 1.x which reached
+ * end of life on March 31, 2018. Move to a supported HTTP client.
  */
+@Deprecated
 public class EurekaServerRegistry implements ServerRegistry {
 
   private final ConcurrentHashMap<String, ServerEntry> serversByVip = new ConcurrentHashMap<>();

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/NetflixJsonObjectDecoder.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/NetflixJsonObjectDecoder.java
@@ -36,7 +36,11 @@ import java.util.List;
  * This class does not do any real parsing or validation. A sequence of bytes is considered a JSON object/array
  * if it contains a matching number of opening and closing braces/brackets. It's up to a subsequent
  * {@link ChannelHandler} to parse the JSON text into a more usable form i.e. a POJO.
+ *
+ * @deprecated This library depends on RxNetty which is unsupported and RxJava 1.x which reached
+ * end of life on March 31, 2018. Move to a supported HTTP client.
  */
+@Deprecated
 public class NetflixJsonObjectDecoder extends ByteToMessageDecoder {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(NetflixJsonObjectDecoder.class);

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/RxHttp.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/RxHttp.java
@@ -69,7 +69,11 @@ import java.util.zip.GZIPOutputStream;
 /**
  * Helper for some simple uses of rxnetty with eureka. Only intended for use within the spectator
  * plugin.
+ *
+ * @deprecated This library depends on RxNetty which is unsupported and RxJava 1.x which reached
+ * end of life on March 31, 2018. Move to a supported HTTP client.
  */
+@Deprecated
 @Singleton
 public final class RxHttp implements AutoCloseable {
 

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/Server.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/Server.java
@@ -17,7 +17,11 @@ package com.netflix.iep.http;
 
 /**
  * Represents a server to try and connect to.
+ *
+ * @deprecated This library depends on RxNetty which is unsupported and RxJava 1.x which reached
+ * end of life on March 31, 2018. Move to a supported HTTP client.
  */
+@Deprecated
 public final class Server {
   /** Id for servers that are not created as part of a server registry. */
   public static final String UNREGISTERED_HOST_ID = "UNREGISTERED";

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerRegistry.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerRegistry.java
@@ -20,7 +20,11 @@ import java.util.List;
 /**
  * Represents the server registry used for client-side load balancing. Primarily so we don't
  * need to create an actual DiscoveryClient instance in unit tests.
+ *
+ * @deprecated This library depends on RxNetty which is unsupported and RxJava 1.x which reached
+ * end of life on March 31, 2018. Move to a supported HTTP client.
  */
+@Deprecated
 public interface ServerRegistry {
 
   /**

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerSentEvent.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerSentEvent.java
@@ -23,7 +23,11 @@ import java.nio.charset.Charset;
 
 /**
  * Server sent event message.
+ *
+ * @deprecated This library depends on RxNetty which is unsupported and RxJava 1.x which reached
+ * end of life on March 31, 2018. Move to a supported HTTP client.
  */
+@Deprecated
 public final class ServerSentEvent {
 
   private static ByteBuf toByteBuf(String s) {


### PR DESCRIPTION
Deprecates `iep-rxhttp`, `iep-config`, and `iep-module-archaius1`
libraries. These have been getting gradually phased out over time,
but will now provide deprecation warnings if used.