### PR TITLE
support basic client settings for AWS v2

### DIFF
--- a/iep-module-aws/README.md
+++ b/iep-module-aws/README.md
@@ -70,7 +70,7 @@ Module module = new AbstractModule() {
 Injector injector = Guice.createInjector(module, new AwsModule());
 
 // Get instance
-AmazonEC2 dflt = factory.newInstance(AmazonEC2.class);
+AmazonEC2 dflt = injector.getInstance(AmazonEC2.class);
 ```
 
 ### Multi-Account Usage

--- a/iep-module-aws2/README.md
+++ b/iep-module-aws2/README.md
@@ -1,9 +1,121 @@
 
 ## Description
 
-Experimental bindings for [AWS SDK for Java 2][aws2].
+Creates bindings for a factory to create clients using [AWS SDK for Java v2.0]. The clients can
+be configured so that the region, basic client configuration, and credential provider can be
+tuned as needed in the configuration file.
 
-[aws2]: https://aws.amazon.com/blogs/developer/aws-sdk-for-java-2-0-developer-preview/
+[AWS SDK for Java v2.0]: https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/welcome.html
+
+### Configuration
+
+For more complete settings see the [reference.conf]. A quick example is shown below:
+
+[reference.conf](https://github.com/Netflix/iep/blob/master/iep-module-aws2/src/main/resources/reference.conf)
+
+```hocon
+netflix.iep.aws {
+  // By default the name of the client is the service name as seen in the package.
+  ec2 {
+    // If not specified, then the local endpoint for the service will be chosen.
+    region = "us-east-1"
+
+    // Client configuration settings can be set in the client block.
+    client {
+      api-call-attempt-timeout = 5s
+    }
+
+    // Instead of using DefaultCredentialsProvider do an assume role
+    credentials {
+      role-arn = "arn:aws:iam::1234567890:role/IepTest"
+      role-session-name = "foo"
+    }
+  }
+
+  // You can also use a custom name and reference it explicitly
+  foo-client {
+    // ...
+  }
+}
+```
+
+### Typical Usage
+
+```java
+// Add the module to the injector
+Injector injector = Guice.createInjector(new AwsModule());
+
+// Get factory instance and create a client
+AwsClientFactory factory = injector.getInstance(AwsClientFactory.class);
+Ec2Client dflt = factory.newInstance(Ec2Client.class);
+Ec2Client foo = factory.newInstance("foo-client", Ec2Client.class);
+
+// Works with sync or async clients
+Ec2AsyncClient dflt = factory.newInstance(Ec2AsyncClient.class);
+Ec2AsyncClient foo = factory.newInstance("foo-client", Ec2AsyncClient.class);
+```
+
+### Injecting Client Interface
+
+Sometimes it is more useful to directly inject the client interface rather than injecting the
+`AwsClientFactory`. For example, the client interface is easier to mock out for unit tests.
+This module does not create bindings for every client or have dependencies on all of the
+sub-packages for the AWS SDK. However, it is straightforward to create a binding for the
+interface yourself:
+
+```java
+// Add the module to the injector
+Module module = new AbstractModule() {
+  @Override protected void configure() {
+  }
+
+  @Provides
+  private Ec2Client providesEC2(AwsClientFactory factory) {
+    return factory.newInstance(Ec2Client.class);
+  }
+};
+Injector injector = Guice.createInjector(module, new AwsModule());
+
+// Get instance
+Ec2Client dflt = injector.getInstance(Ec2Client.class);
+```
+
+### Multi-Account Usage
+
+When building an application that needs to communicate with many accounts, the factory can be
+used to assume role into a specified account. Use a place holder in the role-arn setting:
+
+```hocon
+netflix.iep.aws {
+  default {
+    credentials {
+      // The account placeholder will get replaced by the requested account id
+      role-arn = "arn:aws:iam::{account}:role/IepTest"
+      role-session-name = "foo"
+    }
+  }
+}
+```
+
+Then when creating a new client pass in the account id, for example:
+
+```java
+AwsClientFactory factory = injector.getInstance(AwsClientFactory.class);
+Ec2Client client1 = factory.newInstance(Ec2Client.class, "12345");
+Ec2Client client2 = factory.newInstance(Ec2Client.class, "54321");
+```
+
+The `newInstance` call will always create a new instance of the client. To reuse a shared client
+for a given account use `getInstance`:
+
+```java
+AwsClientFactory factory = injector.getInstance(AwsClientFactory.class);
+Ec2Client client1 = factory.getInstance(Ec2Client.class, "12345");
+Ec2Client client2 = factory.getInstance(Ec2Client.class, "54321");
+
+// This will be the same instance as client1
+Ec2Client client3 = factory.getInstance(Ec2Client.class, "12345");
+```
 
 ## Gradle
 

--- a/iep-module-aws2/src/main/resources/reference.conf
+++ b/iep-module-aws2/src/main/resources/reference.conf
@@ -12,43 +12,20 @@ netflix.iep.aws {
     }
 
     client {
-      // For more information see:
-      // http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html
-      // http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/constant-values.html#com.amazonaws.ClientConfiguration.DEFAULT_CONNECTION_TIMEOUT
-      //use-reaper = true
-      //use-tcp-keep-alive = false
-      //use-throttle-retries = false
-      //max-connections = 50
-      //connection-ttl = 60s
-      //connection-max-idle = 60s
-      //connection-timeout = 50s
-      //socket-timeout = 50s
+      // Timeout for the overall request, total time including all retries
+      //api-call-timeout = 300s
 
-      // Needs to be set to false for S3. If the client automatically decompresses the object
-      // content then the hash verification will fail:
-      //
-      // com.amazonaws.AmazonClientException: Unable to verify integrity of data download.
-      // Client calculated content hash didn't match hash calculated by Amazon S3. The data may
-      // be corrupt.
-      use-gzip = true
-      s3.use-gzip = false
+      // Timeout for an individual attempt
+      //apt-attempt-call-timeout = 30s
 
-      // Defaults to -1, not set, but cannot be explicitly set to that value
-      //max-error-retry = -1
+      // Other headers
+      //headers = [
+      //  "Accept: gzip"
+      //]
 
-      // Sometimes useful to customize for logging, but the default value is typically good enough.
-      // Sample of default:
-      // aws-sdk-java/1.8.9.1 Linux/3.2.0-54-virtual Java_HotSpot(TM)_64-Bit_Server_VM/25.0-b70/1.8.0
+      // Customizing the user agent
       //user-agent-prefix
       //user-agent-suffix
-
-      // If you need to proxy:
-      //proxy-port
-      //proxy-host
-      //proxy-domain
-      //proxy-workstation
-      //proxy-username
-      //proxy-password
     }
   }
 

--- a/iep-module-aws2/src/test/resources/aws-client-factory.conf
+++ b/iep-module-aws2/src/test/resources/aws-client-factory.conf
@@ -3,16 +3,15 @@ netflix.iep.aws {
 
   default {
     client {
-      user-agent-prefix = "abc"
-      user-agent-suffix = "xyz"
-      use-gzip = true
+      user-agent-prefix = "default"
+      user-agent-suffix = "suffix"
     }
   }
 
   // Override ignore all root level settings
   ec2-test {
     client {
-      use-gzip = false
+      user-agent-prefix = "ignored-defaults"
     }
 
     credentials {
@@ -24,58 +23,30 @@ netflix.iep.aws {
   // Inherit defaults, but override some settings
   ec2-test-default = ${netflix.iep.aws.default} {
     client {
-      use-gzip = false
-    }
-  }
-
-  boolean-true {
-    client {
-      use-reaper = true
-      use-tcp-keep-alive = true
-      use-gzip = true
-      use-throttle-retries = true
-    }
-  }
-
-  boolean-false {
-    client {
-      use-reaper = false
-      use-tcp-keep-alive = false
-      use-gzip = false
-      use-throttle-retries = false
+      user-agent-prefix = "override-defaults"
     }
   }
 
   timeouts {
     client {
-      socket-timeout = 42s
-      connection-timeout = 51s
-      client-execution-timeout = 13s
+      api-call-attempt-timeout = 42s
+      api-call-timeout = 13s
     }
   }
 
-  ttl {
+  headers {
     client {
-      connection-ttl = 42s
-      connection-max-idle = 51s
+      headers = [
+        "Accept-Encoding: gzip"
+      ]
     }
   }
 
-  integers {
+  headers-invalid {
     client {
-      max-connections = 27
-      max-error-retry = 3
-    }
-  }
-
-  proxy {
-    client {
-      proxy-port = 12345
-      proxy-host = "host"
-      proxy-domain = "domain"
-      proxy-workstation = "workstation"
-      proxy-username = "username"
-      proxy-password = "password"
+      headers = [
+        "Accept-Encoding"
+      ]
     }
   }
 }


### PR DESCRIPTION
Updates the v2 client factory to support setting basic settings
on the client such as timeouts and headers. We do not currently
have a use-case for a custom HTTP client, so we'll look at
supporting that in the future if a use-case comes up.