### PR TITLE
userservice: fix cache age metric

### DIFF
--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/AbstractUserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/AbstractUserService.java
@@ -66,7 +66,7 @@ abstract class AbstractUserService extends AbstractService implements UserServic
     if (enabled) {
       PolledMeter.using(registry)
           .withId(cacheAge)
-          .monitorValue(new AtomicLong(clock.wallTime()), Functions.age(clock));
+          .monitorValue(lastUpdateTime, Functions.age(clock));
     }
   }
 
@@ -102,7 +102,6 @@ abstract class AbstractUserService extends AbstractService implements UserServic
       lastUpdateTime.set(context.registry().clock().wallTime());
       return true;
     } catch (Exception e) {
-      e.printStackTrace();
       logger.warn("failed to refresh users list", e);
       return false;
     }

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/Context.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/Context.java
@@ -100,6 +100,7 @@ public final class Context implements AutoCloseable {
         .withRetries(2)
         .acceptJson()
         .acceptGzip()
+        .customizeLogging(entry -> entry.withEndpoint(name))
         .send()
         .decompress();
   }


### PR DESCRIPTION
A reference to the AtomicLong for the PolledMeter was not
retained so it would get garbage collected and stop reporting.

Also removes an unnecessary print stack trace call and updates
the client to set the endpoint for metrics. Since the remote
service in this case does not have the headers set, it is not
picked up automatically.