### PR TITLE
Add leader election component

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ lazy val root = project.in(file("."))
     `iep-eureka-testconfig`,
     `iep-guice`,
     `iep-launcher`,
+    `iep-leader-api`,
+    `iep-leader-dynamodb`,
     `iep-module-admin`,
     `iep-module-archaius1`,
     `iep-module-archaius2`,
@@ -17,6 +19,7 @@ lazy val root = project.in(file("."))
     `iep-module-awsmetrics`,
     `iep-module-eureka`,
     `iep-module-jmxport`,
+    `iep-module-leader`,
     `iep-module-rxnetty`,
     `iep-module-userservice`,
     `iep-nflxenv`,
@@ -64,6 +67,25 @@ lazy val `iep-guice` = project
 
 lazy val `iep-launcher` = project
   .configure(BuildSettings.profile)
+
+lazy val `iep-leader-api` = project
+  .configure(BuildSettings.profile)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.inject,
+    Dependencies.slf4jApi,
+    Dependencies.spectatorApi,
+    Dependencies.typesafeConfig,
+    Dependencies.assertjcore % "test",
+    Dependencies.equalsVerifier % "test"
+  ))
+
+lazy val `iep-leader-dynamodb` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`iep-leader-api`, `iep-module-aws2`)
+  .settings(libraryDependencies ++= Seq(
+      Dependencies.aws2DynamoDB,
+      Dependencies.spectatorApi
+  ))
 
 lazy val `iep-module-admin` = project
   .configure(BuildSettings.profile)
@@ -186,6 +208,18 @@ lazy val `iep-module-jmxport` = project
   .settings(libraryDependencies ++= Seq(
     Dependencies.guiceCore,
     Dependencies.slf4jApi
+  ))
+
+lazy val `iep-module-leader` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`iep-leader-api`, `iep-service`)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.guiceCore,
+    Dependencies.guiceMulti,
+    Dependencies.slf4jApi,
+    Dependencies.spectatorApi,
+    Dependencies.typesafeConfig,
+    Dependencies.assertjcore % "test"
   ))
 
 lazy val `iep-module-rxnetty` = project

--- a/iep-leader-api/README.md
+++ b/iep-leader-api/README.md
@@ -1,0 +1,66 @@
+
+## Description
+
+Simple leader election API for cases that a single entity within a group should complete tasks for a
+set of _resources_. _Resource_ in this context is defined by an entity that can be identified by a
+Unique ID. _Sharding_ is not currently supported natively in this API. However, one can select
+resources using a sharding algorithm externally and then use this API for leadership management.
+
+Supporting correctness guarantees is not specified by the API and up to the implementation. See
+[How to do distributed locking][kleppmann], for a detailed exploration of distributed locking in
+support of correctness vs efficiency.
+
+[kleppmann]: https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html
+
+### Usage
+
+Typical usage consists of binding `LeaderElector` and `LeaderStatus` to `StandardLeaderElector`
+using an inversion of control framework, such as Guice or Spring Injection. One can also instantiate
+`StandardLeaderElector` directly. `initialize()` should be called before any other methods. After
+that, the other methods may be interleaved in any fashion. `runElection()` should be called
+periodically based upon the value of `iep.leader.leaderElectorFrequency` which, in turn, should be
+set to something reasonable based upon `iep.leader.maxIdleDuration`.
+
+### Configuration
+
+A value for the `iep.leader.leaderId` property must be set.
+
+If the resources comprise a constant list, optionally set the property `iep.leader.resourceIds`.
+Resources can be added with either of, or combination of, that property and programmatically with
+the `LeaderElector.addResource()` API.
+
+NOTE: The default `LeaderDatabase` implementation in `iep-leader-dynamodb` sets the leader ID to the
+instance ID and the resource IDs to the single value of the cluster name as the default.
+
+Additional configuration options are documented inline in `reference.conf`.
+
+### Metrics
+
+#### leader.removalFailure
+
+**Unit:** failures/second
+
+**Dimensions:**
+
+* `resource`: The ID of the resource for which removal of the leader failed.
+* `exception`: The simple name of the exception that occurred.
+* Common Infrastructure
+
+#### leader.resourceLeader
+
+**Unit:** boolean - 1.0 if reporting instance is leader of `resource`, 0.0 if not
+
+**Dimensions:**
+
+* `resource`: The ID of the resource.
+* `leader`: The leader ID.
+* Common Infrastructure
+
+#### leader.resourceWithNoLeader
+
+**Unit:** boolean - 1.0 if the leader of `resource` is specifically _NO_LEADER_, 0.0 otherwise
+
+**Dimensions:**
+
+* `resource`: The ID of the resource.
+* Common Infrastructure

--- a/iep-leader-api/src/main/java/com/netflix/iep/leader/StandardLeaderElector.java
+++ b/iep-leader-api/src/main/java/com/netflix/iep/leader/StandardLeaderElector.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader;
+
+import com.netflix.iep.leader.api.LeaderDatabase;
+import com.netflix.iep.leader.api.LeaderElector;
+import com.netflix.iep.leader.api.LeaderId;
+import com.netflix.iep.leader.api.LeaderStatus;
+import com.netflix.iep.leader.api.ResourceId;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * {@code StandardLeaderElector} is a canonical implementation of {@link LeaderElector} and
+ * {@link LeaderStatus}. It promotes consistency of metrics and logging, while allowing for
+ * different backing {@link LeaderDatabase} implementations. It also provides flexibility in how to
+ * react to faults, such as whether to keep or remove the local view of leadership status in the
+ * face of errors during {@code LeaderDatabase} operations.
+ * <p>
+ * This implementation expects the {@code LeaderDatabase} implementation to be thread-safe. If that
+ * condition is met, this class is thread-safe.
+ * <p>
+ * For additional documentation, see the following files in this project:
+ * <li>{@code reference.conf} - the full list of configuration options</li>
+ * <li>{@code README.conf} - the metrics provided</li>
+ */
+@Singleton
+public class StandardLeaderElector implements LeaderElector, LeaderStatus {
+
+  private static final Logger logger = LoggerFactory.getLogger(StandardLeaderElector.class);
+
+  private final LeaderId leaderId;
+  private final LeaderDatabase leaderDatabase;
+  private final Config config;
+  private final ConcurrentMap<ResourceId, LeaderId> resourceLeaders;
+  private final Registry registry;
+
+  private final Id leaderRemovalFailureCounterId;
+  private final Id resourceLeaderGaugeId;
+  private final Id resourceWithNoLeaderGaugeId;
+
+  @Inject
+  public StandardLeaderElector(LeaderDatabase leaderDatabase, Config config, Registry registry) {
+    this(
+        LeaderId.create(config),
+        leaderDatabase,
+        config,
+        registry,
+        initializeResourceLeaderMap(ResourceId.create(config)),
+        registry.createId("leader.removalFailure"),
+        registry.createId("leader.resourceLeader"),
+        registry.createId("leader.resourceWithNoLeader")
+    );
+  }
+
+  public StandardLeaderElector(
+      LeaderId leaderId,
+      LeaderDatabase leaderDatabase,
+      Config config,
+      Registry registry,
+      Map<ResourceId, LeaderId> resourceLeaders,
+      Id leaderRemovalFailureCounterId,
+      Id resourceLeaderGaugeId,
+      Id resourceWithNoLeaderGaugeId
+  ) {
+    Objects.requireNonNull(leaderId, "leaderId");
+    Objects.requireNonNull(leaderDatabase, "dbTable");
+    Objects.requireNonNull(config, "config");
+    Objects.requireNonNull(registry, "registry");
+    Objects.requireNonNull(resourceLeaders, "resourceLeaders");
+    Objects.requireNonNull(leaderRemovalFailureCounterId, "leaderRemovalFailureCounterId");
+    Objects.requireNonNull(resourceLeaderGaugeId, "resourceLeaderGaugeId");
+    Objects.requireNonNull(resourceWithNoLeaderGaugeId, "resourceWithNoLeaderGaugeId");
+
+    this.leaderId = leaderId;
+    this.leaderDatabase = leaderDatabase;
+    this.config = config;
+    this.registry = registry;
+    this.resourceLeaders = new ConcurrentHashMap<>(resourceLeaders); // defensive copy
+
+    this.leaderRemovalFailureCounterId = leaderRemovalFailureCounterId;
+    this.resourceLeaderGaugeId = resourceLeaderGaugeId;
+    this.resourceWithNoLeaderGaugeId = resourceWithNoLeaderGaugeId;
+  }
+
+  // visible for testing
+  static Map<ResourceId, LeaderId> initializeResourceLeaderMap(Collection<ResourceId> ids) {
+    return ids.stream().collect(Collectors.toMap(Function.identity(), s -> LeaderId.UNKNOWN));
+  }
+
+  @Override
+  public boolean addResource(ResourceId resourceId) {
+    final boolean addResource = !resourceLeaders.containsKey(resourceId);
+    if (addResource) {
+      resourceLeaders.put(resourceId, LeaderId.UNKNOWN);
+    }
+
+    return addResource;
+  }
+
+  @Override
+  public LeaderId getLeaderFor(ResourceId resourceId) {
+    return resourceLeaders.getOrDefault(resourceId, LeaderId.UNKNOWN);
+  }
+
+  @Override
+  public Set<ResourceId> getResources() {
+    return Collections.unmodifiableSet(resourceLeaders.keySet());
+  }
+
+  @Override
+  public void initialize() {
+    leaderDatabase.initialize();
+  }
+
+  @Override
+  public boolean removeLeaderFor(ResourceId resourceId) {
+    boolean removed = false;
+    try {
+      removed = leaderDatabase.removeLeadershipFor(resourceId);
+      if (removed) {
+        resourceLeaders.put(resourceId, LeaderId.NO_LEADER);
+      }
+    } catch (Exception e) {
+      if (removeLocalLeaderStatusOnError()) {
+        resourceLeaders.put(resourceId, LeaderId.UNKNOWN);
+      }
+
+      final String exceptionName = e.getCause() != null ?
+          e.getCause().getClass().getSimpleName() : e.getClass().getSimpleName();
+      registry.counter(
+          leaderRemovalFailureCounterId
+              .withTag("resource", resourceId.getId())
+              .withTag("exception", exceptionName)
+      )
+      .increment();
+      logger.error("Exception during leader removal", e);
+    }
+
+    return removed;
+  }
+
+  @Override
+  public boolean removeResource(ResourceId resourceId) {
+    final boolean removed = resourceLeaders.remove(resourceId) != null;
+    if (removed) {
+      registry.gauge(
+          resourceLeaderGaugeId
+              .withTag("resource", resourceId.getId())
+              .withTag("leader", leaderId.getId()))
+          .set(0.0);
+    }
+    return removed;
+  }
+
+  @Override
+  public void runElection() {
+    resourceLeaders.entrySet().forEach(entry -> {
+      final ResourceId resourceId = entry.getKey();
+      LeaderId newLeaderId;
+      try {
+        leaderDatabase.updateLeadershipFor(resourceId);
+        newLeaderId = leaderDatabase.getLeaderFor(resourceId);
+      } catch (Exception e) {
+        logger.error("Exception during leader election", e);
+        if (removeLocalLeaderStatusOnError()) {
+          newLeaderId = LeaderId.UNKNOWN;
+        } else {
+          newLeaderId = this.leaderId;
+        }
+      }
+      entry.setValue(newLeaderId);
+      final Id idWithResourceTag = resourceLeaderGaugeId.withTag("resource", resourceId.getId());
+
+      final boolean hasLeadership = this.leaderId.equals(newLeaderId);
+      // always set this leader's value
+      registry
+          .gauge(idWithResourceTag.withTag("leader", leaderId.getId()))
+          .set(hasLeadership ? 1.0 : 0.0);
+
+      if (!hasLeadership) {
+        // If this leader doesn't have leadership, this provides a view of which leader this
+        // instance maintains has leadership.
+        registry.gauge(idWithResourceTag.withTag("leader", newLeaderId.getId())).set(0.0);
+      }
+
+      // NO_LEADER for an extended period suggests something isn't right.
+      final boolean noLeader = newLeaderId.equals(LeaderId.NO_LEADER);
+      registry
+          .gauge(resourceWithNoLeaderGaugeId.withTag("resource", resourceId.getId()))
+          .set(noLeader ? 1.0 : 0.0);
+    });
+  }
+
+  @Override
+  public boolean hasLeadership() {
+    return resourceLeaders.values().stream().allMatch(leaderId::equals);
+  }
+
+  @Override
+  public boolean hasLeadershipFor(ResourceId resourceId) {
+    return getLeaderFor(resourceId).equals(leaderId);
+  }
+
+  private boolean removeLocalLeaderStatusOnError() {
+    return config.getBoolean("iep.leader.removeLocalLeaderStatusOnError");
+  }
+}

--- a/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderDatabase.java
+++ b/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderDatabase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.iep.leader.api;
+
+/**
+ * {@code LeaderDatabase} provides operations for storage, update, and access to the set of managed
+ * resources and the current leader of each.
+ */
+public interface LeaderDatabase {
+
+  /**
+   * Perform any required initialization for this {@code LeaderDatabase}.
+   */
+  void initialize();
+
+  /**
+   * Retrieve the current leader for {@code resourceId}.
+   */
+  LeaderId getLeaderFor(ResourceId resourceId);
+
+  /**
+   * For {@code resourceId}, conditionally insert or update its record with the configured
+   * {@code iep.leader.leaderId} if the criteria for assuming leadership are met.
+   */
+  boolean updateLeadershipFor(ResourceId resourceId);
+
+  /**
+   * For {@code resourceId}, update its record to {@link LeaderId#NO_LEADER} if its current leader
+   * is the configured {@code iep.leader.leaderId} of this instance.
+   */
+  boolean removeLeadershipFor(ResourceId resourceId);
+
+}

--- a/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderDatabase.java
+++ b/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderDatabase.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.iep.leader.api;
 
 /**

--- a/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderElector.java
+++ b/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderElector.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader.api;
+
+import java.util.Set;
+
+/**
+ * Leader elector provides operations to manage the leader election lifecycle.
+ */
+public interface LeaderElector {
+
+  /**
+   * Add a resourceId for this {@code LeaderElector} to manage. {@link #getLeaderFor(ResourceId)}
+   * will return {@link LeaderId#UNKNOWN} for {@code resourceId} until the next time
+   * {@link #runElection()} completes.
+   *
+   * @return true if {@code resourceId} was added, false if not
+   */
+  boolean addResource(ResourceId resourceId);
+
+  /**
+   * @return the ID of the current leader for {@code resourceId}
+   */
+  LeaderId getLeaderFor(ResourceId resourceId);
+
+  /**
+   * @return a point in time, immutable view of the set of resources managed by this
+   * {@code LeaderElector}
+   */
+  Set<ResourceId> getResources();
+
+  /**
+   * Perform any required initialization of this {@code LeaderElector} to ensure it is ready for
+   * use.
+   */
+  void initialize();
+
+  /**
+   * Remove the current leader for {@code resourceId}.
+   * <p>
+   * If {@code true} is returned from a call to this API, {@link #getLeaderFor(ResourceId)} must
+   * return {@link LeaderId#NO_LEADER} for {@code resourceId} until the next time
+   * {@link #runElection()} completes.
+   * <p>
+   * If {@code false} is returned due to an error, the behavior for
+   * {@link #getLeaderFor(ResourceId)} is dictated by the property
+   * {@code iep.leader.removeLocalLeaderStatusOnError}.
+   *
+   * @return true if leadership for {@code resourceId} was removed, false if not
+   */
+  boolean removeLeaderFor(ResourceId resourceId);
+
+  /**
+   * Remove {@code resourceId} from this {@code LeaderElector}'s set of resources.
+   *
+   * @return true if {@code resourceId} was removed, false if not
+   */
+  boolean removeResource(ResourceId resourceId);
+
+  /**
+   * Run an election.
+   */
+  void runElection();
+}

--- a/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderId.java
+++ b/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderId.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader.api;
+
+import com.typesafe.config.Config;
+
+import java.util.Objects;
+
+/**
+ * An identifier for a leader that may lead a resource.
+ */
+public final class LeaderId {
+
+  private static final String LEADER_ID_CONFIG_PATH = "iep.leader.leaderId";
+
+  private final String id;
+
+  /**
+   * Constant for when there is currently no elected leader.
+   */
+  public static final LeaderId NO_LEADER = new LeaderId("NO_LEADER");
+
+  /**
+   * Constant for when the is currently elected leader is not known.
+   */
+  public static final LeaderId UNKNOWN = new LeaderId("UNKNOWN");
+
+  /**
+   * Constructs a {@code LeaderId} using value provided in {@code config} for
+   * {@link #LEADER_ID_CONFIG_PATH}.
+   */
+  public static LeaderId create(Config config) {
+    try {
+      return new LeaderId(config.getString(LEADER_ID_CONFIG_PATH));
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid '" + LEADER_ID_CONFIG_PATH + "'", e);
+    }
+  }
+
+  /**
+   * Returns a {@code LeaderId} for {@code id}, creating one if necessary.
+   *
+   * @param id an ID that is unique among the entities that can lead the resource
+   * @throws NullPointerException if {@code id} is null
+   * @throws IllegalArgumentException if {@code id} is empty
+   */
+  public static LeaderId create(String id) {
+    final LeaderId leaderId;
+    switch (id) {
+      case "NO_LEADER":
+        leaderId = LeaderId.NO_LEADER;
+        break;
+      case "UNKNOWN":
+        leaderId = LeaderId.UNKNOWN;
+        break;
+      default:
+        leaderId = new LeaderId(id);
+    }
+
+    return leaderId;
+  }
+
+  private LeaderId(String id) {
+    Objects.requireNonNull(id, "id");
+    if (id.isEmpty()) {
+      throw new IllegalArgumentException("id is empty");
+    }
+
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String toString() {
+    return "LeaderId{" +
+        "id='" + id + '\'' +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LeaderId leaderId = (LeaderId) o;
+    return id.equals(leaderId.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderStatus.java
+++ b/iep-leader-api/src/main/java/com/netflix/iep/leader/api/LeaderStatus.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader.api;
+
+/**
+ * The current leadership status.
+ */
+public interface LeaderStatus {
+
+  /**
+   * @return true, if leadership is held for the specified resource
+   */
+  boolean hasLeadershipFor(ResourceId resource);
+
+  /**
+   * @return true, if leadership is held for all resources
+   * <p>
+   * Note: This API exists primarily for convenience for the common case that only one resource
+   * is managed by the {@link LeaderElector}.
+   */
+  boolean hasLeadership();
+}

--- a/iep-leader-api/src/main/java/com/netflix/iep/leader/api/ResourceId.java
+++ b/iep-leader-api/src/main/java/com/netflix/iep/leader/api/ResourceId.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader.api;
+
+import com.typesafe.config.Config;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * An identifier for a resource that needs a leader.
+ */
+public final class ResourceId {
+
+  private final String id;
+
+  public static final String RESOURCE_IDS_CONFIG_PATH = "iep.leader.resourceIds";
+
+  /**
+   * Creates a collection of {@code ResourceId}s using the values provided in {@code config} for
+   * {@link #RESOURCE_IDS_CONFIG_PATH}.
+   */
+  public static Collection<ResourceId> create(Config config) {
+    final Collection<ResourceId> resourceIds;
+    if (config.hasPath(RESOURCE_IDS_CONFIG_PATH)) {
+      resourceIds = config.getStringList(RESOURCE_IDS_CONFIG_PATH)
+          .stream()
+          .map(ResourceId::new)
+          .collect(Collectors.toList());
+    } else {
+      resourceIds = Collections.emptyList();
+    }
+
+    return resourceIds;
+  }
+
+  /**
+   * Constructs a {@code ResourceId}.
+   *
+   * @param id an ID that is unique within the scope of visibility of the entities that can lead
+   *           the resource
+   * @throws NullPointerException if {@code id} is null
+   * @throws IllegalArgumentException if {@code id} is empty
+   */
+  public ResourceId(String id) {
+    Objects.requireNonNull(id, "id");
+    if (id.isEmpty()) {
+      throw new IllegalArgumentException("id is empty");
+    }
+
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String toString() {
+    return "ResourceId{" +
+        "id='" + id + '\'' +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ResourceId that = (ResourceId) o;
+    return id.equals(that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/iep-leader-api/src/main/resources/reference.conf
+++ b/iep-leader-api/src/main/resources/reference.conf
@@ -1,0 +1,19 @@
+
+iep {
+  leader {
+
+    // Run an election at this frequency.
+    leaderElectorFrequency = 20s
+
+    // Resources become eligible for a new leader if the current time exceeds the last update by
+    // this duration.
+    maxIdleDuration = 80s
+
+    // Whether to remove leadership locally in the case that an error occurs during an election
+    // cycle. This can be used to aid meeting correctness requirements (e.g., no work completed may
+    // be better than multiple workers for non-idempotent operations).
+    // remove = false risks multiple leaders
+    // remove = true  risks no leader
+    removeLocalLeaderStatusOnError = false
+  }
+}

--- a/iep-leader-api/src/test/java/com/netflix/iep/leader/StandardLeaderElectorTest.java
+++ b/iep-leader-api/src/test/java/com/netflix/iep/leader/StandardLeaderElectorTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.iep.leader;
+
+import com.netflix.iep.leader.api.LeaderDatabase;
+import com.netflix.iep.leader.api.LeaderElector;
+import com.netflix.iep.leader.api.LeaderId;
+import com.netflix.iep.leader.api.ResourceId;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.assertj.core.util.Lists;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+@RunWith(JUnit4.class)
+public class StandardLeaderElectorTest {
+  private final String defaultConfigString = createConfigString(false);
+  private final Config defaultConfig = ConfigFactory.parseString(defaultConfigString);
+  private final DefaultRegistry defaultRegistry = new DefaultRegistry();
+  private final Id resourceLeaderGaugeId = defaultRegistry.createId("leader.test.resourceLeader");
+  private final Id noLeaderGaugeId = defaultRegistry.createId("leader.test.resourceWithNoLeader");
+  private final Id removalFailureMetricId = defaultRegistry.createId("leader.test.removalFailure");
+  private final LeaderId leaderId = LeaderId.create("test-leader");
+  private final LeaderId otherLeaderId = LeaderId.create("test-other-leader");
+  private TestableLeaderDatabase testableLeaderDatabase;
+  private StandardLeaderElector leaderElector;
+
+  private String createConfigString(boolean removeLocalLeaderOnError) {
+    return String.format(
+        "%s = %b%n",
+        "iep.leader.removeLocalLeaderStatusOnError",
+        removeLocalLeaderOnError);
+  }
+
+  @Before
+  public void setup() {
+    testableLeaderDatabase = new TestableLeaderDatabase(leaderId, otherLeaderId);
+    leaderElector = createLeaderElector(defaultConfig);
+  }
+
+  @After
+  public void tearDown() {
+    defaultRegistry.reset();
+  }
+
+  private StandardLeaderElector createLeaderElector(Config config) {
+    return new StandardLeaderElector(
+        leaderId,
+        testableLeaderDatabase,
+        config,
+        defaultRegistry,
+        new HashMap<>(),
+        removalFailureMetricId,
+        resourceLeaderGaugeId,
+        noLeaderGaugeId
+    );
+  }
+
+  @Test
+  public void initializeResourceLeaderMapHandlesEmptyCollection() {
+    final Map<ResourceId, LeaderId> resourceIdLeaderIdMap =
+        StandardLeaderElector.initializeResourceLeaderMap(Collections.emptyList());
+    assertThat(resourceIdLeaderIdMap).isEmpty();
+  }
+
+  @Test
+  public void initializeResourceLeaderMapHandlesOneResource() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+    final Map<ResourceId, LeaderId> resourceIdLeaderIdMap =
+        StandardLeaderElector.initializeResourceLeaderMap(Lists.list(id1));
+
+    assertThat(resourceIdLeaderIdMap).hasSize(1);
+    assertThat(resourceIdLeaderIdMap).containsEntry(id1, LeaderId.UNKNOWN);
+  }
+
+  @Test
+  public void initializeResourceLeaderMapHandlesMultipleResources() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+    final ResourceId id2 = new ResourceId("test-resource-two");
+    final ResourceId id3 = new ResourceId("test-resource-three");
+    final Map<ResourceId, LeaderId> resourceIdLeaderIdMap =
+        StandardLeaderElector.initializeResourceLeaderMap(Lists.list(id1, id2, id3));
+
+    assertThat(resourceIdLeaderIdMap)
+        .extractingFromEntries(Map.Entry::getKey, Map.Entry::getValue)
+        .containsExactlyInAnyOrder(
+            tuple(id1, LeaderId.UNKNOWN),
+            tuple(id2, LeaderId.UNKNOWN),
+            tuple(id3, LeaderId.UNKNOWN)
+        );
+  }
+
+  @Test
+  public void resourceIsAdded() {
+    final ResourceId resourceId = new ResourceId("resourceIsAdded");
+    assertThat(leaderElector.addResource(resourceId)).isTrue();
+    assertThat(leaderElector.getResources()).containsExactly(resourceId);
+  }
+
+  @Test
+  public void multipleResourcesAreAdded() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+    final ResourceId id2 = new ResourceId("test-resource-two");
+    assertThat(leaderElector.addResource(id1)).isTrue();
+    assertThat(leaderElector.addResource(id2)).isTrue();
+    assertThat(leaderElector.getResources()).containsExactly(id1, id2);
+  }
+
+  @Test
+  public void resourceIsRemoved() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+    final ResourceId id2 = new ResourceId("test-resource-two");
+    leaderElector.addResource(id1);
+    leaderElector.addResource(id2);
+    assertThat(leaderElector.getResources()).containsExactly(id1, id2);
+    assertThat(leaderElector.removeResource(id1)).isTrue();
+    assertThat(leaderElector.getResources()).doesNotContain(id1);
+    assertThat(leaderElector.getResources()).contains(id2);
+  }
+
+  @Test
+  public void newResourceHasUnknownLeader() {
+    final ResourceId resourceId = new ResourceId("noLeaderResource");
+    leaderElector.addResource(resourceId);
+    assertThat(leaderElector.getLeaderFor(resourceId)).isEqualTo(LeaderId.UNKNOWN);
+  }
+
+  @Test
+  public void getLeaderReturnsUnknownLeaderForUnknownResource() {
+    final ResourceId resourceId = new ResourceId("UnknownResource");
+    leaderElector.addResource(resourceId);
+    assertThat(leaderElector.getLeaderFor(resourceId)).isEqualTo(LeaderId.UNKNOWN);
+  }
+
+  @Test
+  public void getResourcesReturnsSetThatIsNotModifiable() {
+    final ResourceId resourceId = new ResourceId("test-resource");
+    leaderElector.addResource(resourceId);
+    assertThatThrownBy(() ->
+        leaderElector.getResources().add(new ResourceId("another-test-resource"))
+    )
+    .isExactlyInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void leaderElectorInitializesDatabase() {
+    leaderElector.initialize();
+    assertThat(testableLeaderDatabase.initialized).isTrue();
+  }
+
+  @Test
+  public void runElectionChoosesThisLeaderOnWin() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+    final ResourceId id2 = new ResourceId("test-resource-two");
+
+    leaderElector.addResource(id1);
+    leaderElector.addResource(id2);
+
+    leaderElector.runElection();
+
+    assertThat(leaderElector.getLeaderFor(id1)).isEqualTo(leaderId);
+    assertThat(leaderElector.getLeaderFor(id2)).isEqualTo(leaderId);
+  }
+
+  @Test
+  public void runElectionChoosesOtherLeaderOnNoWin() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+    final ResourceId id2 = new ResourceId("test-resource-two");
+
+    leaderElector.addResource(id1);
+    leaderElector.addResource(id2);
+
+    testableLeaderDatabase.winLeadershipInUpdate = false;
+    leaderElector.runElection();
+
+    assertThat(leaderElector.getLeaderFor(id1)).isEqualTo(otherLeaderId);
+    assertThat(leaderElector.getLeaderFor(id2)).isEqualTo(otherLeaderId);
+  }
+
+  @Test
+  public void runElectionExceptionKeepsExistingLeaderWhenConfiguredTo() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+
+    leaderElector.addResource(id1);
+
+    leaderElector.runElection();
+    assertThat(leaderElector.getLeaderFor(id1)).isEqualTo(leaderId);
+
+    testableLeaderDatabase.winLeadershipInUpdate = false;
+    testableLeaderDatabase.throwExceptionInUpdate = true;
+    leaderElector.runElection();
+    assertThat(leaderElector.getLeaderFor(id1)).isEqualTo(leaderId);
+  }
+
+  @Test
+  public void runElectionExceptionRemovesLocalLeaderWhenConfiguredTo() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+    final Config config = ConfigFactory.parseString(createConfigString(true));
+    final LeaderElector leaderElector = createLeaderElector(config);
+
+    leaderElector.addResource(id1);
+
+    leaderElector.runElection();
+    assertThat(leaderElector.getLeaderFor(id1)).isEqualTo(leaderId);
+
+    testableLeaderDatabase.winLeadershipInUpdate = false;
+    testableLeaderDatabase.throwExceptionInUpdate = true;
+    leaderElector.runElection();
+    assertThat(leaderElector.getLeaderFor(id1)).isEqualTo(LeaderId.UNKNOWN);
+  }
+
+  @Test
+  public void runElectionSetsGaugeWithLeader() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+    leaderElector.addResource(id1);
+
+    final Id idWithResourceTag = resourceLeaderGaugeId.withTag("resource", id1.getId());
+    final Id leaderMetricId = idWithResourceTag.withTag("leader", leaderId.getId());
+    final Id otherLeaderMetricId = idWithResourceTag.withTag("leader", otherLeaderId.getId());
+
+    final Gauge leaderGauge = defaultRegistry.gauge(leaderMetricId);
+    final Gauge otherLeaderGauge = defaultRegistry.gauge(otherLeaderMetricId);
+    final Gauge noLeaderGauge =
+        defaultRegistry.gauge(noLeaderGaugeId.withTag("resource", id1.getId()));
+
+    testableLeaderDatabase.winLeadershipInUpdate = true;
+    leaderElector.runElection();
+
+    assertThat(leaderGauge.value()).isEqualTo(1.0);
+    assertThat(otherLeaderGauge.value()).isNaN();
+    assertThat(noLeaderGauge.value()).isEqualTo(0.0);
+
+    testableLeaderDatabase.winLeadershipInUpdate = false;
+    leaderElector.runElection();
+
+    assertThat(leaderGauge.value()).isEqualTo(0.0);
+    // Tag is set, but value is meant to be 0.0 to indicate the reporting instance is not the leader
+    assertThat(otherLeaderGauge.value()).isEqualTo(0.0);
+    assertThat(noLeaderGauge.value()).isEqualTo(0.0);
+
+    testableLeaderDatabase.winLeadershipInUpdate = true;
+    leaderElector.runElection();
+
+    assertThat(leaderGauge.value()).isEqualTo(1.0);
+    assertThat(otherLeaderGauge.value()).isEqualTo(0.0);
+    assertThat(noLeaderGauge.value()).isEqualTo(0.0);
+  }
+
+  @Test
+  public void runElectionSetsResourceLeaderGaugeToUnknownWhenRemoveLocalLeaderIsConfigured() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+    final Config config = ConfigFactory.parseString(createConfigString(true));
+    final LeaderElector leaderElector = createLeaderElector(config);
+
+    leaderElector.addResource(id1);
+
+    leaderElector.runElection();
+    assertThat(leaderElector.getLeaderFor(id1)).isEqualTo(leaderId);
+
+    testableLeaderDatabase.winLeadershipInUpdate = false;
+    testableLeaderDatabase.throwExceptionInUpdate = true;
+    leaderElector.runElection();
+
+    final Gauge leaderGauge = defaultRegistry.gauge(
+        resourceLeaderGaugeId
+            .withTag("resource", id1.getId())
+            .withTag("leader", LeaderId.UNKNOWN.getId())
+    );
+    assertThat(leaderGauge.value()).isEqualTo(0.0);
+
+    final Gauge noLeaderGauge =
+        defaultRegistry.gauge(noLeaderGaugeId.withTag("resource", id1.getId()));
+    // only set to 1.0 if the leader is specifically set to NO_LEADER
+    assertThat(noLeaderGauge.value()).isEqualTo(0.0);
+  }
+
+  @Test
+  public void runElectionSetsResourceLeaderGaugeToNoLeaderWhenTheResourceHasNoLeader() {
+    final ResourceId id1 = new ResourceId("test-resource-one");
+
+    leaderElector.addResource(id1);
+
+    final Gauge noLeaderGauge =
+        defaultRegistry.gauge(noLeaderGaugeId.withTag("resource", id1.getId()));
+
+    testableLeaderDatabase.winLeadershipInUpdate = true;
+    leaderElector.runElection();
+    assertThat(leaderElector.getLeaderFor(id1)).isEqualTo(leaderId);
+    assertThat(noLeaderGauge.value()).isEqualTo(0.0);
+
+    testableLeaderDatabase.winLeadershipInUpdate = false;
+    leaderElector.removeLeaderFor(id1);
+    leaderElector.runElection();
+    assertThat(leaderElector.getLeaderFor(id1)).isEqualTo(LeaderId.NO_LEADER);
+
+    assertThat(noLeaderGauge.value()).isEqualTo(1.0);
+
+    testableLeaderDatabase.winLeadershipInUpdate = true;
+    leaderElector.runElection();
+    assertThat(noLeaderGauge.value()).isEqualTo(0.0);
+  }
+
+  @Test
+  public void runElectionUpdatesTheDatabase() {
+    leaderElector.addResource(new ResourceId("test-resource-one"));
+    leaderElector.runElection();
+    assertThat(testableLeaderDatabase.databaseHitCount).isEqualTo(2);
+  }
+
+  @Test
+  public void removeLeaderUpdatesTheDatabase() {
+    leaderElector.removeLeaderFor(new ResourceId("test-resource-one"));
+    assertThat(testableLeaderDatabase.databaseHitCount).isEqualTo(1);
+  }
+
+  @Test
+  public void hasLeadershipDoesNotHitTheDatabase() {
+    leaderElector.addResource(new ResourceId("test-resource-one"));
+    leaderElector.runElection();
+    int databaseHits = testableLeaderDatabase.databaseHitCount;
+    leaderElector.hasLeadership();
+
+    assertThat(testableLeaderDatabase.databaseHitCount).isEqualTo(databaseHits);
+  }
+
+  @Test
+  public void hasLeadershipForDoesNotHitTheDatabase() {
+    final ResourceId resourceId = new ResourceId("test-resource-one");
+    leaderElector.addResource(resourceId);
+    leaderElector.runElection();
+    int databaseHits = testableLeaderDatabase.databaseHitCount;
+    leaderElector.hasLeadershipFor(resourceId);
+
+    assertThat(testableLeaderDatabase.databaseHitCount).isEqualTo(databaseHits);
+  }
+
+  @Test
+  public void addResourceDoesNotHitTheDatabase() {
+    leaderElector.addResource(new ResourceId("test-resource-one"));
+    assertThat(testableLeaderDatabase.databaseHitCount).isEqualTo(0);
+  }
+
+  @Test
+  public void removeResourceDoesNotHitTheDatabase() {
+    leaderElector.addResource(new ResourceId("test-resource-one"));
+    leaderElector.runElection();
+    int databaseHits = testableLeaderDatabase.databaseHitCount;
+    leaderElector.removeResource(new ResourceId("test-resource-one"));
+    assertThat(testableLeaderDatabase.databaseHitCount).isEqualTo(databaseHits);
+  }
+
+  private static class TestableLeaderDatabase implements LeaderDatabase {
+
+    boolean winLeadershipInUpdate = true;
+    boolean throwExceptionInUpdate = false;
+    boolean allowRemoveLeadership = true;
+
+    boolean initialized = false;
+    int databaseHitCount = 0;
+
+    private final LeaderId leaderId;
+    private final LeaderId otherLeaderId;
+    private final Map<ResourceId, LeaderId> resourceLeaders = new HashMap<>();
+
+    TestableLeaderDatabase(LeaderId leaderId, LeaderId otherLeaderId) {
+      this.leaderId = leaderId;
+      this.otherLeaderId = otherLeaderId;
+    }
+
+    @Override
+    public void initialize() {
+      ++databaseHitCount;
+      initialized = true;
+    }
+
+    @Override
+    public LeaderId getLeaderFor(ResourceId resourceId) {
+      ++databaseHitCount;
+      return resourceLeaders.getOrDefault(resourceId, LeaderId.UNKNOWN);
+    }
+
+    @Override
+    public boolean updateLeadershipFor(ResourceId resourceId) {
+      ++databaseHitCount;
+      if (throwExceptionInUpdate) {
+        throw new RuntimeException("test exception configured for updateLeadershipFor");
+      }
+
+      if (winLeadershipInUpdate) {
+        resourceLeaders.put(resourceId, leaderId);
+      } else if(!resourceLeaders.getOrDefault(resourceId, LeaderId.UNKNOWN)
+          .equals(LeaderId.NO_LEADER)) {
+        resourceLeaders.put(resourceId, otherLeaderId);
+      }
+      return winLeadershipInUpdate;
+    }
+
+    @Override
+    public boolean removeLeadershipFor(ResourceId resourceId) {
+      ++databaseHitCount;
+      if (allowRemoveLeadership &&
+          resourceLeaders.getOrDefault(resourceId, LeaderId.UNKNOWN).equals(leaderId)) {
+        resourceLeaders.put(resourceId, LeaderId.NO_LEADER);
+      }
+      return allowRemoveLeadership;
+    }
+  }
+}

--- a/iep-leader-api/src/test/java/com/netflix/iep/leader/StandardLeaderElectorTest.java
+++ b/iep-leader-api/src/test/java/com/netflix/iep/leader/StandardLeaderElectorTest.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.iep.leader;
 
 import com.netflix.iep.leader.api.LeaderDatabase;

--- a/iep-leader-api/src/test/java/com/netflix/iep/leader/api/LeaderIdTest.java
+++ b/iep-leader-api/src/test/java/com/netflix/iep/leader/api/LeaderIdTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader.api;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@RunWith(JUnit4.class)
+public class LeaderIdTest {
+
+  @Test
+  public void equalsCompliesWithContract() {
+    EqualsVerifier.forClass(LeaderId.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void nullIdThrows() {
+    assertThatNullPointerException().isThrownBy(() -> LeaderId.create((String) null));
+  }
+
+  @Test
+  public void emptyIdThrows() {
+    assertThatIllegalArgumentException().isThrownBy(() -> LeaderId.create(""));
+  }
+
+  @Test
+  public void factoryUsesValueInConfig() {
+    final String id = "test-id";
+    final Config c = ConfigFactory.parseString("iep.leader.leaderId = " + id);
+    final LeaderId leaderId = LeaderId.create(c);
+
+    assertThat(leaderId).isEqualTo(LeaderId.create(id));
+  }
+}

--- a/iep-leader-api/src/test/java/com/netflix/iep/leader/api/ResourceIdTest.java
+++ b/iep-leader-api/src/test/java/com/netflix/iep/leader/api/ResourceIdTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader.api;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@RunWith(JUnit4.class)
+public class ResourceIdTest {
+
+  @Test
+  public void equalsCompliesWithContract() {
+    EqualsVerifier.forClass(ResourceId.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+  }
+
+  @Test
+  public void nullIdThrows() {
+    assertThatNullPointerException().isThrownBy(() -> new ResourceId(null));
+  }
+
+  @Test
+  public void emptyIdThrows() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new ResourceId(""));
+  }
+
+  @Test
+  public void resourceIdsConfigIsOptional() {
+    final Config c = ConfigFactory.empty("ResourceIdTest.resourceIdsConfigIsOptional");
+    final Collection<ResourceId> actualResourceIds = ResourceId.create(c);
+    assertThat(actualResourceIds).isEmpty();
+  }
+
+  @Test
+  public void factoryHandlesEmptyList() {
+    final Config c = ConfigFactory.parseString("iep.leader.resourceIds = []");
+    final Collection<ResourceId> actualResourceIds = ResourceId.create(c);
+
+    assertThat(actualResourceIds).isEmpty();
+  }
+
+  @Test
+  public void factoryHandlesSingleValue() {
+    final String id1 = "test-id-one";
+    final Config c = ConfigFactory.parseString("iep.leader.resourceIds = [" + id1 + "]");
+
+    final Collection<ResourceId> actualResourceIds = ResourceId.create(c);
+
+    assertThat(actualResourceIds).containsExactly(new ResourceId(id1));
+  }
+
+  @Test
+  public void factoryHandlesMultipleValues() {
+    final String id1 = "test-id-one";
+    final String id2 = "test-id-two";
+    final String id3 = "test-id-three";
+    final String idListStr = String.join(",",id1, id2, id3);
+    final Config c = ConfigFactory.parseString("iep.leader.resourceIds = [" + idListStr + "]");
+
+    final Collection<ResourceId> actualResourceIds = ResourceId.create(c);
+
+    assertThat(actualResourceIds).containsExactly(
+        new ResourceId(id1),
+        new ResourceId(id2),
+        new ResourceId(id3)
+    );
+  }
+}

--- a/iep-leader-dynamodb/README.md
+++ b/iep-leader-dynamodb/README.md
@@ -1,0 +1,20 @@
+
+## Description
+
+DynamoDB backed `LeaderDatabase` implementation.
+
+### Usage
+This `LeaderDatabase` implementation can be instantiated directly, injected programmatically, or
+injected. For convenience, a Guice module is provided that is configured for discovery by
+ `java.util.ServiceLoader`.
+ 
+Once an instance is obtained, `initialize()` must be called. This is not called by default, since it
+is a relatively heavy-weight, blocking operation, so is being left to the discretion of the user
+of this API when to call it.
+
+`DynamoDbLeaderDatabase` creates database table and waits for the active status in `initialize()`
+so, once `initialize()` returns, the `LeaderDatabase` is ready for use.
+
+### Configuration
+By default, the leader ID is configured to the instance ID of the host and the resource IDs to the
+single value of the cluster name. See the `reference.conf` file for other configuration options.

--- a/iep-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderDatabase.java
+++ b/iep-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderDatabase.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader.dynamodb;
+
+import com.google.common.collect.Lists;
+import com.netflix.iep.leader.api.LeaderDatabase;
+import com.netflix.iep.leader.api.LeaderId;
+import com.netflix.iep.leader.api.ResourceId;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.TableStatus;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Singleton
+public class DynamoDbLeaderDatabase implements LeaderDatabase {
+
+  public static class TableActiveTimeoutException extends RuntimeException {
+    TableActiveTimeoutException(String message) {
+      super(message);
+    }
+  }
+
+  private static final Logger logger = LoggerFactory.getLogger(DynamoDbLeaderDatabase.class);
+
+  private static final String LEADER_CONFIG_PATH_NAME = "iep.leader";
+  private static final String DB_CONFIG_PATH_NAME = LEADER_CONFIG_PATH_NAME + ".dynamodb";
+
+  private static final String LEADER_ID_PLACEHOLDER = ":leaderId";
+  private static final String LEADER_TIMEOUT_PLACEHOLDER = ":timeoutMillis";
+  private static final String NO_LEADER_PLACEHOLDER = ":noLeader";
+  private static final String NOW_MILLIS_PLACEHOLDER = ":nowMillis";
+
+  // update the record if it doesn't have the leaderId attribute
+  // or the leader ID is my ID
+  // or the timeout threshold has been reached
+  private static final String LEADER_UPDATE_CONDITION_FORMAT =
+      "attribute_not_exists(%s) OR %1$s = %s OR %s <= %s";
+  private static final String LEADER_UPDATE_FORMAT = "SET %s = %s, %s = %s";
+  private static final String LEADER_REMOVE_FORMAT = "SET %s = %s";
+  private static final String LEADER_REMOVE_CONDITION = "%s = %s";
+
+  private final DynamoDbClient db;
+  private final Config config;
+  private final LeaderId leaderId;
+  private final String tableName;
+  private final String hashKeyName;
+  private final Long readCapacityUnits;
+  private final Long writeCapacityUnits;
+  private final Duration tableActiveTimeout;
+  private final String leaderIdAttributeName;
+  private final String lastUpdateAttributeName;
+
+  private final String leaderUpdateExpression;
+  private final String leaderUpdateConditionExpression;
+  private final String removeLeadershipExpression;
+  private final String removeLeadershipConditionExpression;
+
+  @Inject
+  public DynamoDbLeaderDatabase(DynamoDbClient db, Config config) {
+    this(
+        db,
+        config,
+        LeaderId.create(config),
+        config.getString(DB_CONFIG_PATH_NAME + "tableName"),
+        config.getString(DB_CONFIG_PATH_NAME + "tableHashKeyName"),
+        config.getLong(DB_CONFIG_PATH_NAME + "tableReadCapacityUnits"),
+        config.getLong(DB_CONFIG_PATH_NAME + "tableWriteCapacityUnits"),
+        config.getDuration(DB_CONFIG_PATH_NAME + "tableActiveTimeout"),
+        config.getString(DB_CONFIG_PATH_NAME + "leaderIdAttributeName"),
+        config.getString(DB_CONFIG_PATH_NAME + "lastUpdateAttributeName")
+    );
+  }
+
+  public DynamoDbLeaderDatabase(
+      DynamoDbClient db,
+      Config config,
+      LeaderId leaderId,
+      String tableName,
+      String hashKeyName,
+      Long readCapacityUnits,
+      Long writeCapacityUnits,
+      Duration tableActiveTimeout,
+      String leaderIdAttributeName,
+      String lastUpdateAttributeName
+  ) {
+    Objects.requireNonNull(db, "db");
+    Objects.requireNonNull(config, "config");
+    Objects.requireNonNull(leaderId, "leaderId");
+    Objects.requireNonNull(tableName, "tableName");
+    Objects.requireNonNull(hashKeyName, "hashKeyName");
+    Objects.requireNonNull(readCapacityUnits, "readCapacityUnits");
+    Objects.requireNonNull(writeCapacityUnits, "writeCapacityUnits");
+    Objects.requireNonNull(tableActiveTimeout, "tableActiveTimeout");
+    Objects.requireNonNull(leaderIdAttributeName, "leaderIdAttributeName");
+    Objects.requireNonNull(lastUpdateAttributeName, "lastUpdateAttributeName");
+
+    this.db = db;
+    this.config = config;
+    this.leaderId = leaderId;
+    this.tableName = tableName;
+    this.hashKeyName = hashKeyName;
+    this.readCapacityUnits = readCapacityUnits;
+    this.writeCapacityUnits = writeCapacityUnits;
+    this.tableActiveTimeout = tableActiveTimeout;
+    this.leaderIdAttributeName = leaderIdAttributeName;
+    this.lastUpdateAttributeName = lastUpdateAttributeName;
+
+    this.leaderUpdateExpression =
+        formatUpdateLeader(LEADER_UPDATE_FORMAT, NOW_MILLIS_PLACEHOLDER);
+    this.leaderUpdateConditionExpression =
+        formatUpdateLeader(LEADER_UPDATE_CONDITION_FORMAT, LEADER_TIMEOUT_PLACEHOLDER);
+    this.removeLeadershipExpression =
+        formatRemoveLeader(LEADER_REMOVE_FORMAT, NO_LEADER_PLACEHOLDER);
+    this.removeLeadershipConditionExpression =
+        formatRemoveLeader(LEADER_REMOVE_CONDITION, LEADER_ID_PLACEHOLDER);
+  }
+
+  private String formatUpdateLeader(String formatString, String epochMillisPlaceholder) {
+    return String.format(formatString,
+        leaderIdAttributeName,
+        LEADER_ID_PLACEHOLDER,
+        lastUpdateAttributeName,
+        epochMillisPlaceholder
+    );
+  }
+
+  private String formatRemoveLeader(String formatString, String leaderPlaceholder) {
+    return String.format(formatString, leaderIdAttributeName, leaderPlaceholder);
+  }
+
+  @Override
+  public void initialize() {
+    final Collection<AttributeDefinition> attributeDefinitions = Lists.newArrayList(
+        AttributeDefinition
+            .builder()
+            .attributeName(hashKeyName)
+            .attributeType(ScalarAttributeType.S)
+            .build()
+    );
+
+    final Collection<KeySchemaElement> keySchemaElements = Lists.newArrayList(
+        KeySchemaElement
+            .builder()
+            .attributeName(hashKeyName)
+            .keyType(KeyType.HASH)
+            .build()
+    );
+
+    final ProvisionedThroughput provisionedThroughput =
+        ProvisionedThroughput
+            .builder()
+            .readCapacityUnits(readCapacityUnits)
+            .writeCapacityUnits(writeCapacityUnits)
+            .build();
+
+    final CreateTableRequest createTableRequest =
+        CreateTableRequest
+            .builder()
+            .tableName(tableName)
+            .keySchema(keySchemaElements)
+            .attributeDefinitions(attributeDefinitions)
+            .provisionedThroughput(provisionedThroughput)
+            .build();
+
+    try {
+      CreateTableResponse tableResult = db.createTable(createTableRequest);
+      logger.info("Created table '{}': Table Status = {}, SDK HTTP Response = {}",
+          tableName,
+          tableResult.tableDescription().tableStatusAsString(),
+          tableResult.sdkHttpResponse().statusCode()
+      );
+    } catch (ResourceInUseException e) {
+      logger.debug("Did not create table '{}'; it already exists", tableName);
+    }
+
+    waitUntilTableIsActive(db, tableName, tableActiveTimeout);
+  }
+
+  @Override
+  public LeaderId getLeaderFor(ResourceId resourceId) {
+    final String resourceIdStr = resourceId.getId();
+    final Map<String, AttributeValue> resourceRecordKey = Collections.singletonMap(
+        hashKeyName, AttributeValue.builder().s(resourceIdStr).build()
+    );
+
+    final GetItemRequest request =
+        GetItemRequest
+            .builder()
+            .tableName(tableName)
+            .key(resourceRecordKey)
+            .projectionExpression(leaderIdAttributeName)
+            .consistentRead(true)
+            .build();
+
+    LeaderId leader = LeaderId.NO_LEADER;
+    try {
+      final Map<String, AttributeValue> itemMap = db.getItem(request).item();
+
+      if (itemMap != null) {
+        final AttributeValue leaderIdAttrVal = itemMap.get(leaderIdAttributeName);
+        if (leaderIdAttrVal != null) {
+          leader = LeaderId.create(leaderIdAttrVal.s());
+        }
+      }
+    } catch (ResourceNotFoundException e) {
+      logger.warn("No current record for resource " + resourceIdStr, e);
+    }
+    return leader;
+  }
+
+  @Override
+  public boolean updateLeadershipFor(ResourceId resource) {
+    final String resourceId = resource.getId();
+
+    boolean updated;
+    try {
+      final Instant now = Instant.now();
+      final Duration leaderMaxIdleDuration =
+          config.getDuration(LEADER_CONFIG_PATH_NAME + ".maxIdleDuration");
+      final Instant leaderTimeoutInstant = now.minus(leaderMaxIdleDuration);
+
+      final Map<String, AttributeValue> resourceRecordKey = Collections.singletonMap(
+          hashKeyName, AttributeValue.builder().s(resourceId).build()
+      );
+
+      final Map<String, AttributeValue> expressionAttributeValues = new HashMap<>(2, 1.0f);
+      expressionAttributeValues.put(NOW_MILLIS_PLACEHOLDER,
+          AttributeValue.builder().n(String.valueOf(now.toEpochMilli())).build()
+      );
+      expressionAttributeValues.put(LEADER_TIMEOUT_PLACEHOLDER,
+          AttributeValue.builder().n(String.valueOf(leaderTimeoutInstant.toEpochMilli())).build()
+      );
+
+      final UpdateItemRequest updateRequest =
+          UpdateItemRequest
+              .builder()
+              .tableName(tableName)
+              .key(resourceRecordKey)
+              .updateExpression(leaderUpdateExpression)
+              .conditionExpression(leaderUpdateConditionExpression)
+              .expressionAttributeValues(expressionAttributeValues)
+              .build();
+
+      updated = db.updateItem(updateRequest).sdkHttpResponse().isSuccessful();
+    } catch (ConditionalCheckFailedException e) {
+      logger.debug("There is already an active leader for resource: {}", resourceId);
+      updated = false;
+    }
+
+    return updated;
+  }
+
+  @Override
+  public boolean removeLeadershipFor(ResourceId resourceId) {
+    boolean removed;
+    try {
+      final Map<String, AttributeValue> resourceRecordKey = Collections.singletonMap(
+          hashKeyName, AttributeValue.builder().s(resourceId.getId()).build()
+      );
+
+      final Map<String, AttributeValue> leaderIdAttributeMap = Collections.singletonMap(
+          LEADER_ID_PLACEHOLDER, AttributeValue.builder().s(leaderId.getId()).build()
+      );
+
+      final UpdateItemRequest updateRequest = UpdateItemRequest.builder()
+          .tableName(tableName)
+          .key(resourceRecordKey)
+          .updateExpression(removeLeadershipExpression)
+          .conditionExpression(removeLeadershipConditionExpression)
+          .expressionAttributeValues(leaderIdAttributeMap)
+          .build();
+
+      removed = db.updateItem(updateRequest).sdkHttpResponse().isSuccessful();
+    } catch (ConditionalCheckFailedException e) {
+      logger.debug(
+          "Didn't remove leader attribute for {}; this {} is not its leader.",
+          resourceId,
+          leaderId.getId());
+      removed = false;
+    }
+
+    return removed;
+  }
+
+  private void waitUntilTableIsActive(
+      DynamoDbClient db,
+      String tableName,
+      Duration tableActiveTimeout
+  ) {
+    final Instant timeoutInstant = Instant.now().plus(tableActiveTimeout);
+    final Duration waitDuration = Duration.ofSeconds(20L);
+    while (Instant.now().isBefore(timeoutInstant)) {
+      logger.debug("Checking if table '{}' is active", tableName);
+
+      if (tableIsActive(db, tableName)) return;
+
+      logger.debug("Table '{}' is not yet active, waiting ${waitDuration}", tableName);
+      try {
+        Thread.sleep(waitDuration.toMillis());
+      } catch (InterruptedException e) {
+        logger.warn("Interrupted while waiting for table '{}' to become active", tableName);
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    final String message = String.format(
+        "Table '%s' did not transition to active within: %s",
+        tableName, tableActiveTimeout.toString()
+    );
+    logger.error(message);
+    throw new TableActiveTimeoutException(message);
+  }
+
+  private boolean tableIsActive(DynamoDbClient db, String tableName) {
+    boolean isActive;
+    try {
+      final DescribeTableResponse tableStatusResult =
+          db.describeTable(DescribeTableRequest.builder().tableName(tableName).build());
+      final TableStatus tableStatus = tableStatusResult.table().tableStatus();
+      logger.debug("Table status = {}", tableStatus);
+      isActive = tableStatus.equals(TableStatus.ACTIVE);
+    } catch (ResourceNotFoundException e) {
+      logger.debug("Table '{}' doesn't exist yet... waiting", tableName);
+      isActive = false;
+    }
+    return isActive;
+  }
+}

--- a/iep-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderModule.java
+++ b/iep-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderModule.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.iep.leader.dynamodb;
 
 import com.google.inject.AbstractModule;

--- a/iep-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderModule.java
+++ b/iep-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderModule.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.iep.leader.dynamodb;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.netflix.iep.aws2.AwsClientFactory;
+import com.netflix.iep.leader.api.LeaderDatabase;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+import javax.inject.Singleton;
+
+public class DynamoDbLeaderModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    bind(LeaderDatabase.class).to(DynamoDbLeaderDatabase.class);
+  }
+
+  @Singleton
+  @Provides
+  public DynamoDbClient providesDynamoDb(AwsClientFactory factory) {
+    return factory.newInstance(DynamoDbClient.class);
+  }
+}

--- a/iep-leader-dynamodb/src/main/resources/META-INF/services/com.google.inject.Module
+++ b/iep-leader-dynamodb/src/main/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.iep.leader.dynamodb.DynamoDbLeaderModule

--- a/iep-leader-dynamodb/src/main/resources/reference.conf
+++ b/iep-leader-dynamodb/src/main/resources/reference.conf
@@ -1,0 +1,22 @@
+
+iep {
+  leader {
+
+    dynamodb {
+      lastUpdateAttributeName = "LastUpdateEpochMillis"
+      leaderIdAttributeName = "LeaderId"
+      tableActiveTimeoutSeconds = 600
+      tableHashKeyName = "ResourceId"
+      tableName = ${netflix.iep.env.app}"ResourceLeader"
+      tableReadCapacityUnits = 30
+      tableWriteCapacityUnits = 30
+    }
+
+    leaderId = ${netflix.iep.env.instance-id}
+
+    resourceIds = [
+      ${netlix.iep.env.cluster}
+    ]
+
+  }
+}

--- a/iep-module-leader/README.md
+++ b/iep-module-leader/README.md
@@ -1,0 +1,52 @@
+
+## Description
+
+This component provides a default service and injection module for leader election. By default, it
+binds the `StandardLeaderElector` implementation for the `LeaderElector` and `LeaderStatus`
+interfaces.
+
+### Basic Usage
+
+```java
+public class YourAppService extends AbstractService {
+  @Inject
+  public YourAppService(LeaderStatus leaderStatus) {
+    this.leaderStatus = leaderStatus;
+  }
+
+  private void runTask() {
+    if(leaderStatus.hasLeadership()) {
+      // do the task
+    }
+  }
+}
+```
+
+For the common use case of a single leader in a cluster for a single resource, there is minimal
+effort required to get to the above. See the `README.md` files in the other components for info on
+additional features, such as leadership for multiple resources.
+
+The steps are as follows:
+
+1. Add a dependency to this module.
+2. Add a dependency for a `LeaderDatabase` implementation, such as `iep-leader-dynamodb`.
+3. `@Inject` a `LeaderStatus` into the component that needs to check leadership status (code above).
+4. Start your service using `com.netflix.iep.guice.Main.run(args, new YourAppModule());`
+
+### Metrics
+
+#### leader.electionFailure
+
+**Unit:** failures/second
+
+**Dimensions:**
+
+* Common Infrastructure
+
+#### leader.timeSinceLastElection
+
+**Unit:** seconds 
+
+**Dimensions:**
+
+* Common Infrastructure

--- a/iep-module-leader/src/main/java/com/netflix/iep/leader/LeaderModule.java
+++ b/iep-module-leader/src/main/java/com/netflix/iep/leader/LeaderModule.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import com.netflix.iep.leader.api.LeaderElector;
+import com.netflix.iep.leader.api.LeaderStatus;
+import com.netflix.iep.service.Service;
+
+public class LeaderModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    Multibinder.newSetBinder(binder(), Service.class).addBinding().to(LeaderService.class);
+
+    bind(LeaderElector.class).to(StandardLeaderElector.class);
+    bind(LeaderStatus.class).to(StandardLeaderElector.class);
+  }
+}

--- a/iep-module-leader/src/main/java/com/netflix/iep/leader/LeaderService.java
+++ b/iep-module-leader/src/main/java/com/netflix/iep/leader/LeaderService.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.leader;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.iep.leader.api.LeaderElector;
+import com.netflix.iep.leader.api.ResourceId;
+import com.netflix.iep.service.AbstractService;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Functions;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.patterns.PolledMeter;
+import com.netflix.spectator.impl.Scheduler;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * {@code LeaderService} manages periodic leader election using the provided {@link LeaderElector}.
+ */
+@Singleton
+public class LeaderService extends AbstractService {
+
+  private static final Logger logger = LoggerFactory.getLogger(LeaderService.class);
+
+  private final LeaderElector leaderElector;
+  private final Scheduler.Options leaderElectorSchedulerOptions;
+  private final Scheduler leaderElectorScheduler;
+  private final Counter leaderElectionFailureCounter;
+  private final AtomicLong timeSinceLastElection;
+  private final Registry registry;
+  // visible for testing
+  final Runnable leaderServiceTask = createLeaderServiceTask();
+
+  private volatile boolean running = false;
+
+  @Inject
+  public LeaderService(LeaderElector leaderElector, Config config, Registry registry) {
+    this(
+        leaderElector,
+        registry,
+        new Scheduler(registry, "iep-leader-elector", 1),
+        configureSchedulerOptions(config),
+        registry.counter("leader.electionFailure"),
+        new AtomicLong()
+    );
+
+  }
+
+  public LeaderService(
+      LeaderElector leaderElector,
+      Registry registry,
+      Scheduler leaderElectorScheduler,
+      Scheduler.Options leaderElectorSchedulerOptions,
+      Counter leaderElectionFailureCounter,
+      AtomicLong timeSinceLastElection) {
+    Objects.requireNonNull(leaderElector, "leaderElector");
+    Objects.requireNonNull(registry, "registry");
+    Objects.requireNonNull(leaderElectorScheduler, "leaderElectorScheduler");
+    Objects.requireNonNull(leaderElectorSchedulerOptions, "leaderElectorSchedulerOptions");
+    Objects.requireNonNull(leaderElectionFailureCounter, "leaderElectionFailureCounter");
+    Objects.requireNonNull(timeSinceLastElection, "timeSinceLastElection");
+
+    this.leaderElector = leaderElector;
+    this.registry = registry;
+    this.leaderElectorScheduler = leaderElectorScheduler;
+    this.leaderElectorSchedulerOptions = leaderElectorSchedulerOptions;
+    this.leaderElectionFailureCounter = leaderElectionFailureCounter;
+    this.timeSinceLastElection = timeSinceLastElection;
+  }
+
+  @VisibleForTesting
+  static Scheduler.Options configureSchedulerOptions(Config config) {
+    return new Scheduler.Options().withFrequency(
+        Scheduler.Policy.FIXED_DELAY,
+        config.getDuration("iep.leader.leaderElectorFrequency")
+    );
+  }
+
+  @Override
+  protected void startImpl() {
+    logger.info("Starting leader service");
+
+    leaderElector.initialize();
+
+    running = true;
+    startMonitoringTimeSinceLastElection();
+    leaderElectorScheduler.schedule(leaderElectorSchedulerOptions, leaderServiceTask);
+
+    logger.info("Leader service started");
+  }
+
+  private void startMonitoringTimeSinceLastElection() {
+    timeSinceLastElection.set(registry.clock().wallTime());
+    PolledMeter.using(registry)
+        .withName("leader.timeSinceLastElection")
+        .monitorValue(timeSinceLastElection, Functions.AGE);
+  }
+
+  private Runnable createLeaderServiceTask() {
+    return () -> {
+      try {
+        if (running) {
+          logger.info("Running an election.");
+          leaderElector.runElection();
+          timeSinceLastElection.set(registry.clock().wallTime());
+        } else {
+          logger.info("Skipping election run.");
+        }
+      } catch (Throwable t) {
+        leaderElectionFailureCounter.increment();
+        logger.warn("Leader election attempt failed", t);
+      }
+    };
+  }
+
+  @Override
+  protected void stopImpl() {
+    running = false;
+
+    logger.info("Stopping leader service");
+
+    leaderElectorScheduler.shutdown();
+    removeLeadership();
+
+    logger.info("Leader service stopped");
+  }
+
+  private void removeLeadership() {
+    for (ResourceId resourceId : leaderElector.getResources()) {
+      if (!leaderElector.removeLeaderFor(resourceId)) {
+        logger.warn(
+            "While removing leadership for all resources, could not remove leadership for: {}",
+            resourceId
+        );
+      }
+    }
+  }
+}

--- a/iep-module-leader/src/main/resources/META-INF/services/com.google.inject.Module
+++ b/iep-module-leader/src/main/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.iep.leader.LeaderModule

--- a/iep-module-leader/src/test/java/com/netflix/iep/leader/LeaderServiceTest.java
+++ b/iep-module-leader/src/test/java/com/netflix/iep/leader/LeaderServiceTest.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.iep.leader;
 
 import com.google.common.collect.Sets;

--- a/iep-module-leader/src/test/java/com/netflix/iep/leader/LeaderServiceTest.java
+++ b/iep-module-leader/src/test/java/com/netflix/iep/leader/LeaderServiceTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.iep.leader;
+
+import com.google.common.collect.Sets;
+import com.netflix.iep.leader.api.LeaderElector;
+import com.netflix.iep.leader.api.LeaderId;
+import com.netflix.iep.leader.api.ResourceId;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.impl.Scheduler;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(JUnit4.class)
+public class LeaderServiceTest {
+
+  private LeaderService leaderService;
+  private CountingLeaderElector leaderElector;
+  private CountDownLatch leaderElectorLatch;
+  private final AtomicLong timeSinceLastElection = new AtomicLong();
+
+  @Before
+  public void setUp() throws Exception {
+    leaderElectorLatch = new CountDownLatch(1);
+    leaderElector = new CountingLeaderElector();
+    final Registry registry = new DefaultRegistry();
+    final Scheduler.Options leaderElectorSchedulerOptions = new Scheduler.Options()
+        .withFrequency(Scheduler.Policy.RUN_ONCE, Duration.ZERO);
+    final Scheduler leaderElectorScheduler = new Scheduler(registry, "test", 1);
+    final Counter leaderElectionFailureCounter = registry.counter("leaderElectionFailureCounter");
+    leaderService = new LeaderService(
+        leaderElector,
+        registry,
+        leaderElectorScheduler,
+        leaderElectorSchedulerOptions,
+        leaderElectionFailureCounter,
+        timeSinceLastElection);
+
+    leaderService.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    leaderService.stop();
+  }
+
+  @Test
+  public void runElectionIsCalled() throws Exception {
+    leaderElectorLatch.await(1, TimeUnit.SECONDS);
+    assertThat(leaderElector.runElectionCount).isEqualTo(1);
+  }
+
+  @Test
+  public void initializeIsCalled() throws Exception {
+    leaderElectorLatch.await(1, TimeUnit.SECONDS);
+    assertThat(leaderElector.initializationCount).isEqualTo(1);
+  }
+
+  @Test
+  public void removeLeadersIsCalled() throws Exception {
+    leaderService.stop();
+    leaderElectorLatch.await(1, TimeUnit.SECONDS);
+    assertThat(leaderElector.removeLeaderCount).isEqualTo(1);
+  }
+
+  @Test
+  public void configureSchedulerOptionsUsesConfigForFrequency() {
+    // have to test indirectly, since Scheduler.Options does not allow access to the configured
+    // options and there is a bias against using mocking frameworks in `iep`
+    final String configString = "iep.leader.bad.path = 10s";
+    final Config config = ConfigFactory.parseString(configString);
+
+    assertThatThrownBy(() -> LeaderService.configureSchedulerOptions(config))
+        .hasMessageContaining("iep.leader.leaderElectorFrequency");
+  }
+
+  @Test
+  public void timeSinceLastElectionIsSet() throws Exception {
+    leaderElectorLatch.await(1, TimeUnit.SECONDS);
+    long firstElectionTime = this.timeSinceLastElection.get();
+    Thread.sleep(300);
+    leaderService.leaderServiceTask.run();
+    final long lastElectionTime = timeSinceLastElection.get();
+    final Duration electionInterval = Duration.ofMillis(lastElectionTime - firstElectionTime);
+
+    System.out.println(electionInterval);
+    assertThat(electionInterval).isGreaterThan(Duration.ofMillis(295));
+  }
+
+  private class CountingLeaderElector implements LeaderElector {
+    int initializationCount = 0;
+    int runElectionCount = 0;
+    int removeLeaderCount = 0;
+    private final HashSet<ResourceId> resourceIds = Sets.newHashSet(new ResourceId("test"));
+
+    @Override
+    public boolean addResource(ResourceId resourceId) {
+      return false;
+    }
+
+    @Override
+    public LeaderId getLeaderFor(ResourceId resourceId) {
+      return LeaderId.NO_LEADER;
+    }
+
+    @Override
+    public Set<ResourceId> getResources() {
+      return resourceIds;
+    }
+
+    @Override
+    public void initialize() {
+      ++initializationCount;
+    }
+
+    @Override
+    public boolean removeLeaderFor(ResourceId resourceId) {
+      ++removeLeaderCount;
+      return true;
+    }
+
+    @Override
+    public boolean removeResource(ResourceId resourceId) {
+      return false;
+    }
+
+    @Override
+    public void runElection() {
+      ++runElectionCount;
+      leaderElectorLatch.countDown();
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,7 @@ import sbt._
 object Dependencies {
   object Versions {
     val archaius   = "2.3.14"
+    val assertj    = "3.13.1"
     val aws        = "1.11.579"
     val aws2       = "2.6.4"
     val eureka     = "1.9.12"
@@ -23,6 +24,7 @@ object Dependencies {
   val archaiusLegacy     = "com.netflix.archaius" % "archaius-core" % "0.7.6"
   val archaiusPersist    = "com.netflix.archaius" % "archaius2-persisted2" % archaius
   val archaiusTypesafe   = "com.netflix.archaius" % "archaius2-typesafe" % archaius
+  val assertjcore        = "org.assertj" % "assertj-core" % assertj
   val awsAutoScaling     = "com.amazonaws" % "aws-java-sdk-autoscaling" % aws
   val awsCache           = "com.amazonaws" % "aws-java-sdk-elasticache" % aws
   val awsCore            = "com.amazonaws" % "aws-java-sdk-core" % aws


### PR DESCRIPTION
This commit adds a leader election API for cases that a single entity
within a group should complete tasks for a set of resources. The
README.md files in the component modules have detailed information on
use.