### PR TITLE
Invert exit on failure default

### DIFF
--- a/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
@@ -46,7 +46,7 @@ public class Main {
   }
 
   private static boolean exitOnFailure() {
-    return "true".equals(System.getProperty(EXIT_ON_FAILURE_PROP, "true"));
+    return "true".equals(System.getProperty(EXIT_ON_FAILURE_PROP, "false"));
   }
 
   private static List<Module> loadExplicitModules() throws Exception {


### PR DESCRIPTION
The Guice Main helper's default to System.exit upon failure prevented
log statements that were critical to correctly diagnosing an error
from being emitted. The current implementation rethrows the exception
in the alternate case, so it seems equally reasonable to default to
false. This commit switches the default.