### PR TITLE
Fix mismatch in config and missing attribute

### DIFF
--- a/iep-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderDatabase.java
+++ b/iep-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderDatabase.java
@@ -263,6 +263,9 @@ public class DynamoDbLeaderDatabase implements LeaderDatabase {
       );
 
       final Map<String, AttributeValue> expressionAttributeValues = new HashMap<>(2, 1.0f);
+      expressionAttributeValues.put(LEADER_ID_PLACEHOLDER,
+          AttributeValue.builder().s(leaderId.getId()).build()
+      );
       expressionAttributeValues.put(NOW_MILLIS_PLACEHOLDER,
           AttributeValue.builder().n(String.valueOf(now.toEpochMilli())).build()
       );

--- a/iep-leader-dynamodb/src/main/resources/reference.conf
+++ b/iep-leader-dynamodb/src/main/resources/reference.conf
@@ -5,9 +5,9 @@ iep {
     dynamodb {
       lastUpdateAttributeName = "LastUpdateEpochMillis"
       leaderIdAttributeName = "LeaderId"
-      tableActiveTimeoutSeconds = 600
+      tableActiveTimeout = 600s
       tableHashKeyName = "ResourceId"
-      tableName = ${netflix.iep.env.app}"ResourceLeader"
+      tableName = ${netflix.iep.env.app}"-resource-leader"
       tableReadCapacityUnits = 30
       tableWriteCapacityUnits = 30
     }


### PR DESCRIPTION
`tableActiveTimeout` did not match between use and definition.
The leader ID was not being set in the update attribute value.
Hyphenated DynamoDB table name.