### PR TITLE
Default to exit on failure

### DIFF
--- a/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
@@ -46,7 +46,7 @@ public class Main {
   }
 
   private static boolean exitOnFailure() {
-    return "true".equals(System.getProperty(EXIT_ON_FAILURE_PROP, "false"));
+    return "true".equals(System.getProperty(EXIT_ON_FAILURE_PROP, "true"));
   }
 
   private static List<Module> loadExplicitModules() throws Exception {


### PR DESCRIPTION
Upon discussion, though this seems simple on the surface, there are a
number of nuances that make this tricky to get right. For instance,
if a dependency has a non-daemon thread and the failure occurs in such a
way that a service such as discovery sees the app as in service, the app
could take traffic when it shouldn't.

The main change that occurred since this was put in place was a switch
to primarily use async loggers in the Insight Engineering apps. It was
previously observed that synchronous loggers would emit their logs, even
with the call to `System.exit()`. Ideally, we can restore that behavior
with async loggers, but that may also prove to not be easy.