### PR TITLE
use https for jfrog resolver

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -64,7 +64,7 @@ object BuildSettings {
   val resolvers = Seq(
     Resolver.mavenLocal,
     Resolver.jcenterRepo,
-    "jfrog" at "http://oss.jfrog.org/oss-snapshot-local")
+    "jfrog" at "https://oss.jfrog.org/oss-snapshot-local")
 
   // Don't create root.jar, from:
   // http://stackoverflow.com/questions/20747296/producing-no-artifact-for-root-project-with-package-under-multi-project-build-in


### PR DESCRIPTION
Helps avoid risk of MITM attack introducing bad dependencies.