### PR TITLE
fix base version for master

### DIFF
--- a/project/GitVersion.scala
+++ b/project/GitVersion.scala
@@ -6,7 +6,7 @@ import com.typesafe.sbt.SbtGit._
 object GitVersion {
 
   // Base version for master branch
-  private val baseVersion = "v2.0.x"
+  private val baseVersion = "v2.1.x"
 
   // 0.1.x
   private val versionBranch = """v?([0-9\.]+)(?:\.x)?""".r


### PR DESCRIPTION
It wasn't updated to 2.1.x so the snapshots were getting
published to 2.0.0.