### PR TITLE
log warning instead of failing for bad group sizes

### DIFF
--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/JsonUtils.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/JsonUtils.java
@@ -17,7 +17,10 @@ package com.netflix.iep.servergroups;
 
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -28,6 +31,8 @@ import java.util.List;
  * Helper functions for deserializing JSON using Jackson's streaming API.
  */
 final class JsonUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JsonUtils.class);
 
   private static boolean isEndOfArrayOrInput(JsonParser jp) {
     JsonToken t = jp.getCurrentToken();
@@ -100,7 +105,12 @@ final class JsonUtils {
   /** Extract an integer value. */
   static int intValue(JsonParser jp) throws IOException {
     expect(jp, JsonToken.VALUE_NUMBER_INT);
-    int v = jp.getIntValue();
+    int v = -1;
+    try {
+      v = jp.getIntValue();
+    } catch (JsonProcessingException e) {
+      LOGGER.warn("failed to parse value as integer", e);
+    }
     jp.nextToken();
     return v;
   }

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
@@ -67,6 +67,30 @@ public class EddaLoaderTest {
   }
 
   @Test
+  public void overflow() throws Exception {
+    List<ServerGroup> expected = new ArrayList<>();
+    expected.add(ServerGroup.builder()
+        .platform("ec2")
+        .group("app-main-dev-v001")
+        .minSize(-1)
+        .maxSize(-1)
+        .desiredSize(-1)
+        .addInstance(Instance.builder()
+            .node("i-1234567890")
+            .privateIpAddress("10.20.30.40")
+            .vpcId("vpc-54321")
+            .subnetId("subnet-54321")
+            .ami("ami-0987654321")
+            .vmtype("m5.large")
+            .zone("us-east-1d")
+            .status(Instance.Status.NOT_REGISTERED)
+            .build())
+        .build());
+    List<ServerGroup> actual = get("edda-overflow.json");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void noInstances() throws Exception {
     List<ServerGroup> expected = new ArrayList<>();
     expected.add(ServerGroup.builder()

--- a/iep-servergroups/src/test/resources/edda-overflow.json
+++ b/iep-servergroups/src/test/resources/edda-overflow.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "ec2.app-main-dev-v001",
+    "platform": "ec2",
+    "app": "app",
+    "foo": ["bar", "baz", {"abc":  ["def", {}]}],
+    "cluster": "app-main-dev",
+    "group": "app-main-dev-v001",
+    "stack": "main",
+    "detail": "dev",
+    "minSize": 4294967291,
+    "maxSize": 4294967291,
+    "desiredSize": 4294967291,
+    "instances": [
+      {
+        "launchTime": 1544328558000,
+        "node": "i-1234567890",
+        "privateIpAddress": "10.20.30.40",
+        "vpcId": "vpc-54321",
+        "subnetId": "subnet-54321",
+        "ami": "ami-0987654321",
+        "vmtype": "m5.large",
+        "zone": "us-east-1d"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
In some cases we have seen Titus groups that incorrectly
report as having a desired size of `4294967291`. Rather
than fail to load the data, it will now ignore the size
and log a warning locally.