### PR TITLE
add default for include

### DIFF
--- a/iep-nflxenv/src/main/resources/reference.conf
+++ b/iep-nflxenv/src/main/resources/reference.conf
@@ -1,3 +1,6 @@
+// Can be set to specify additional configs to load
+netflix.iep.include = ${?netflix.iep.include} []
+
 // Environment settings frequently used in the Netflix environment. The environment variables
 // used will normally be set automatically if running using the BaseAMI.
 //


### PR DESCRIPTION
Update the reference.conf for iep-nflxenv with a default
value of an empty list of includes. This avoids an error
if the user hasn't explicitly set it.