### PR TITLE
fix deprecation warnings

### DIFF
--- a/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
@@ -55,7 +55,7 @@ public class Main {
     for (String cname : cnames) {
       if (!"".equals(cname)) {
         Class<?> cls = Class.forName(cname);
-        modules.add((Module) cls.newInstance());
+        modules.add((Module) cls.getDeclaredConstructor().newInstance());
       }
     }
     return modules;

--- a/iep-module-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
+++ b/iep-module-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -135,18 +134,6 @@ class AtlasRegistryService extends AbstractService {
     @Override public String validTagCharacters() {
       String pattern = get("atlas.validTagCharacters");
       return (pattern == null) ? "-._A-Za-z0-9" : pattern;
-    }
-
-    @Override public Map<String, String> validTagValueCharacters() {
-      if (config.hasPath("atlas.validTagValueCharacters")) {
-        Map<String, String> tags = new HashMap<>();
-        for (Config cfg : config.getConfigList("atlas.validTagValueCharacters")) {
-          tags.put(cfg.getString("key"), cfg.getString("value"));
-        }
-        return tags;
-      } else {
-        return Collections.emptyMap();
-      }
     }
   }
 }

--- a/iep-module-atlas/src/test/java/com/netflix/iep/atlas/AtlasRegistryServiceTest.java
+++ b/iep-module-atlas/src/test/java/com/netflix/iep/atlas/AtlasRegistryServiceTest.java
@@ -31,9 +31,6 @@ public class AtlasRegistryServiceTest {
     AtlasRegistry registry = (AtlasRegistry) service.getRegistry();
     AtlasConfig config = (AtlasConfig) registry.config();
     Assert.assertEquals("-._A-Za-z0-9", config.validTagCharacters());
-    Assert.assertEquals("-._A-Za-z0-9^~", config.validTagValueCharacters().get("nf.cluster"));
-    Assert.assertEquals("-._A-Za-z0-9^~", config.validTagValueCharacters().get("nf.asg"));
-    Assert.assertNull(config.validTagValueCharacters().get("nf.zone"));
     service.stop();
   }
 }

--- a/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerSentEvent.java
+++ b/iep-rxhttp/src/main/java/com/netflix/iep/http/ServerSentEvent.java
@@ -18,7 +18,6 @@ package com.netflix.iep.http;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**

--- a/iep-rxhttp/src/test/java/com/netflix/iep/http/ByteBufsTest.java
+++ b/iep-rxhttp/src/test/java/com/netflix/iep/http/ByteBufsTest.java
@@ -27,7 +27,6 @@ import rx.functions.Action1;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
1. Remove usage of unused config method from AtlasRegistry.
2. Fix usage of Class.newInstance().