### PR TITLE
add userservice based on HTTP GET check

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -235,6 +235,7 @@ lazy val `iep-module-userservice` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-module-admin`, `iep-service`)
   .settings(libraryDependencies ++= Seq(
+    Dependencies.caffeine,
     Dependencies.guiceCore,
     Dependencies.guiceMulti,
     Dependencies.jacksonMapper,

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/HttpUserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/HttpUserService.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.netflix.iep.service.AbstractService;
+import com.netflix.spectator.ipc.http.HttpResponse;
+import com.typesafe.config.Config;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Calls one or more remote services via HTTP to check if an email is valid. The only
+ * supported call is {@link #isValidEmail(String)}, the others just return an empty set.
+ * Emails checks will get cached to reduce load and improve performance for repeated checks.
+ */
+@Singleton
+public class HttpUserService extends AbstractService implements UserService {
+
+  private final Context context;
+  private final boolean enabled;
+  private final List<? extends Config> uris;
+
+  private final LoadingCache<String, Boolean> cache;
+
+  @Inject
+  HttpUserService(Context context) {
+    this(context, "http");
+  }
+
+  HttpUserService(Context context, String name) {
+    this.context = context;
+
+    Config config = context.config().getConfig(name);
+    this.enabled = config.getBoolean("enabled");
+    this.uris = config.getConfigList("uris");
+
+    this.cache = Caffeine.newBuilder()
+        .expireAfterWrite(config.getDuration("cache-ttl"))
+        .maximumSize(10_000)
+        .build(this::isValidEmailImpl);
+  }
+
+  @Override protected void startImpl() throws Exception {
+  }
+
+  @Override protected void stopImpl() throws Exception {
+  }
+
+  @Override public Set<String> emailAddresses() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public boolean isValidEmail(String email) {
+    String sanitizedEmail = UserUtils.baseAddress(email.toLowerCase(Locale.US));
+    return enabled && checkCache(sanitizedEmail);
+  }
+
+  private boolean checkCache(String email) {
+    Boolean result = cache.get(email);
+    return result != null && result;
+  }
+
+  private boolean isValidEmailImpl(String email) {
+    return uris.stream().anyMatch(c -> checkRemoteService(c, email));
+  }
+
+  private String extractEndpoint(String uri) {
+    // The path is from a static config and is used before substitution of the email. So it
+    // is guaranteed to be bounded.
+    String fixedUri = uri.replace('{', '_').replace('}', '_');
+    return URI.create(fixedUri).getPath();
+  }
+
+  private boolean checkRemoteService(Config config, String email) {
+    final String configUri = config.getString("uri");
+    final String endpoint = extractEndpoint(configUri);
+    final String uri = configUri.replace("{email}", email);
+    final boolean useSslFactory = config.getBoolean("use-ssl-factory");
+    final boolean validOnFailure = config.getBoolean("valid-on-failure");
+    try {
+      HttpResponse response = context.get(endpoint, uri, useSslFactory);
+      int status = response.status();
+      return status == 200 || (status >= 500 && validOnFailure);
+    } catch (Exception e) {
+      return validOnFailure;
+    }
+  }
+}

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/HttpUserService.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/HttpUserService.java
@@ -32,7 +32,7 @@ import java.util.Set;
 /**
  * Calls one or more remote services via HTTP to check if an email is valid. The only
  * supported call is {@link #isValidEmail(String)}, the others just return an empty set.
- * Emails checks will get cached to reduce load and improve performance for repeated checks.
+ * Email checks will get cached to reduce load and improve performance for repeated checks.
  */
 @Singleton
 public class HttpUserService extends AbstractService implements UserService {

--- a/iep-module-userservice/src/main/java/com/netflix/iep/userservice/UserServiceModule.java
+++ b/iep-module-userservice/src/main/java/com/netflix/iep/userservice/UserServiceModule.java
@@ -26,8 +26,10 @@ import com.netflix.spectator.ipc.http.HttpClient;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Setup bindings for {@link UserService}.
@@ -43,6 +45,7 @@ public class UserServiceModule extends AbstractModule {
     userBinder.addBinding().to(EmployeeUserService.class);
     userBinder.addBinding().to(SimpleUserService.class);
     userBinder.addBinding().to(WhitelistUserService.class);
+    userBinder.addBinding().to(HttpUserService.class);
 
     // Show individual startup as part of servicemanager for improved debugging
     Multibinder<Service> serviceBinder = Multibinder.newSetBinder(binder(), Service.class);
@@ -50,6 +53,7 @@ public class UserServiceModule extends AbstractModule {
     serviceBinder.addBinding().to(EmployeeUserService.class);
     serviceBinder.addBinding().to(SimpleUserService.class);
     serviceBinder.addBinding().to(WhitelistUserService.class);
+    serviceBinder.addBinding().to(HttpUserService.class);
     serviceBinder.addBinding().to(CompositeUserService.class);
 
     // Register endpoint to admin to aid in debugging
@@ -76,8 +80,12 @@ public class UserServiceModule extends AbstractModule {
     @Inject(optional = true)
     private HttpClient client = HttpClient.DEFAULT_CLIENT;
 
+    @Named("iep.userservice")
+    @Inject(optional = true)
+    private SSLSocketFactory sslFactory = null;
+
     @Override public Context get() {
-      return new Context(registry, config, client);
+      return new Context(registry, config, client, sslFactory);
     }
   }
 }

--- a/iep-module-userservice/src/main/resources/reference.conf
+++ b/iep-module-userservice/src/main/resources/reference.conf
@@ -31,4 +31,27 @@ netflix.iep.userservice {
       //}
     ]
   }
+
+  http {
+    enabled = false
+
+    // How long to cache emails that have been checked before re-verifying against the remote services
+    cache-ttl = "1d"
+
+    // Order list of uris to check by issuing a GET request. If any of them return 200, then the
+    // email is considered valid. Use `{email}` to substitue the address.
+    uris = [
+      //{
+      //  uri = ""
+      //
+      //  // If set to true, then it will use a custom SSL factory when making the request
+      //  use-ssl-factory = true
+      //
+      //  // This impl will do remote calls inline. If one or more of the calls fails (5xx or exception),
+      //  // then it is unclear whether the email is valid or not. This flag controls the behavior to either
+      //  // reject the email or treat it as valid.
+      //  valid-on-failure = true
+      //}
+    ]
+  }
 }

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/DepartedUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/DepartedUserServiceTest.java
@@ -39,7 +39,7 @@ public class DepartedUserServiceTest {
   private final Config config = ConfigFactory.load();
 
   private Context newContext(HttpClient client) {
-    return new Context(registry, config, client);
+    return new Context(registry, config, client, null);
   }
 
   private HttpResponse ok(String data) {

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/EmployeeUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/EmployeeUserServiceTest.java
@@ -38,7 +38,7 @@ public class EmployeeUserServiceTest {
   private final Config config = ConfigFactory.load();
 
   private Context newContext(HttpClient client) {
-    return new Context(registry, config, client);
+    return new Context(registry, config, client, null);
   }
 
   private HttpResponse ok(String data) {

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/HttpUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/HttpUserServiceTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.userservice;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class HttpUserServiceTest {
+
+  private final ManualClock clock = new ManualClock();
+  private final Registry registry = new DefaultRegistry(clock);
+  private final Config config = ConfigFactory.load();
+  Context ctxt = new Context(registry, config, new TestClient(null), null);
+
+  @Test
+  public void validEmail() {
+    HttpUserService service = new HttpUserService(ctxt, "http-200");
+    Assert.assertTrue(service.isValidEmail("bob@example.com"));
+  }
+
+  @Test
+  public void unknownEmail() {
+    HttpUserService service = new HttpUserService(ctxt, "http-404");
+    Assert.assertFalse(service.isValidEmail("bob@example.com"));
+  }
+
+  @Test
+  public void validOnFailure500() {
+    HttpUserService service = new HttpUserService(ctxt, "http-500-ok");
+    Assert.assertTrue(service.isValidEmail("bob@example.com"));
+  }
+
+  @Test
+  public void notValidOnFailure500() {
+    HttpUserService service = new HttpUserService(ctxt, "http-500-unknown");
+    Assert.assertFalse(service.isValidEmail("bob@example.com"));
+  }
+
+  @Test
+  public void validOnFailureException() {
+    HttpUserService service = new HttpUserService(ctxt, "http-exception-ok");
+    Assert.assertTrue(service.isValidEmail("bob@example.com"));
+  }
+
+  @Test
+  public void notValidOnFailureException() {
+    HttpUserService service = new HttpUserService(ctxt, "http-exception-unknown");
+    Assert.assertFalse(service.isValidEmail("bob@example.com"));
+  }
+
+  @Test
+  public void multipleLastValid() {
+    HttpUserService service = new HttpUserService(ctxt, "http-multiple-200");
+    Assert.assertTrue(service.isValidEmail("bob@example.com"));
+  }
+
+  @Test
+  public void multipleAllUnknown() {
+    HttpUserService service = new HttpUserService(ctxt, "http-multiple-404");
+    Assert.assertFalse(service.isValidEmail("bob@example.com"));
+  }
+
+  @Test
+  public void notEnabled() {
+    HttpUserService service = new HttpUserService(ctxt, "http-not-enabled");
+    Assert.assertFalse(service.isValidEmail("bob@example.com"));
+  }
+
+  @Test
+  public void empty() {
+    HttpUserService service = new HttpUserService(ctxt, "http-empty");
+    Assert.assertFalse(service.isValidEmail("bob@example.com"));
+  }
+}

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/SimpleUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/SimpleUserServiceTest.java
@@ -38,7 +38,7 @@ public class SimpleUserServiceTest {
   private final Config config = ConfigFactory.load();
 
   private Context newContext(HttpClient client) {
-    return new Context(registry, config, client);
+    return new Context(registry, config, client, null);
   }
 
   private HttpResponse ok(String data) {

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/TestClient.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/TestClient.java
@@ -21,6 +21,7 @@ import com.netflix.spectator.ipc.http.HttpResponse;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
 
 class TestClient implements HttpClient {
 
@@ -33,7 +34,12 @@ class TestClient implements HttpClient {
   @Override public HttpRequestBuilder newRequest(URI uri) {
     return new HttpRequestBuilder(HttpClient.DEFAULT_LOGGER, uri) {
       @Override protected HttpResponse sendImpl() throws IOException {
-        return supplier.get();
+        if (supplier != null) {
+          return supplier.get();
+        } else {
+          int status = Integer.parseInt(uri.getHost());
+          return new HttpResponse(status, Collections.emptyMap());
+        }
       }
     };
   }

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/UserServiceEndpointTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/UserServiceEndpointTest.java
@@ -37,7 +37,7 @@ public class UserServiceEndpointTest {
   private final ManualClock clock = new ManualClock();
   private final Registry registry = new DefaultRegistry(clock);
   private final Config config = ConfigFactory.load();
-  private final Context context = new Context(registry, config, HttpClient.DEFAULT_CLIENT);
+  private final Context context = new Context(registry, config, HttpClient.DEFAULT_CLIENT, null);
 
   @Test
   public void list() throws Exception {

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/UserServiceModuleTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/UserServiceModuleTest.java
@@ -43,6 +43,7 @@ public class UserServiceModuleTest {
     expected.add("EmployeeUserService");
     expected.add("SimpleUserService");
     expected.add("WhitelistUserService");
+    expected.add("HttpUserService");
     expected.add("CompositeUserService");
     Set<String> result = manager.services().stream()
         .map(Service::name)

--- a/iep-module-userservice/src/test/java/com/netflix/iep/userservice/WhitelistUserServiceTest.java
+++ b/iep-module-userservice/src/test/java/com/netflix/iep/userservice/WhitelistUserServiceTest.java
@@ -32,7 +32,7 @@ public class WhitelistUserServiceTest {
   private final ManualClock clock = new ManualClock();
   private final Registry registry = new DefaultRegistry(clock);
   private final Config config = ConfigFactory.load();
-  private final Context context = new Context(registry, config, HttpClient.DEFAULT_CLIENT);
+  private final Context context = new Context(registry, config, HttpClient.DEFAULT_CLIENT, null);
 
   @Test
   public void start() throws Exception {

--- a/iep-module-userservice/src/test/resources/application.conf
+++ b/iep-module-userservice/src/test/resources/application.conf
@@ -29,4 +29,121 @@ netflix.iep.userservice {
       }
     ]
   }
+
+  // The HTTP test case treats the host as a status code
+  http-200 {
+    enabled = true
+    cache-ttl = "1d"
+    uris = [
+      {
+        uri = "http://200/{email}"
+        use-ssl-factory = false
+        valid-on-failure = true
+      }
+    ]
+  }
+  http-404 {
+    enabled = true
+    cache-ttl = "1d"
+    uris = [
+      {
+        uri = "http://404/{email}"
+        use-ssl-factory = false
+        valid-on-failure = true
+      }
+    ]
+  }
+  http-500-ok {
+    enabled = true
+    cache-ttl = "1d"
+    uris = [
+      {
+        uri = "http://500/{email}"
+        use-ssl-factory = false
+        valid-on-failure = true
+      }
+    ]
+  }
+  http-500-unknown {
+    enabled = true
+    cache-ttl = "1d"
+    uris = [
+      {
+        uri = "http://500/{email}"
+        use-ssl-factory = false
+        valid-on-failure = false
+      }
+    ]
+  }
+  http-exception-ok {
+    enabled = true
+    cache-ttl = "1d"
+    uris = [
+      {
+        uri = "http://exception/{email}"
+        use-ssl-factory = false
+        valid-on-failure = true
+      }
+    ]
+  }
+  http-exception-unknown {
+    enabled = true
+    cache-ttl = "1d"
+    uris = [
+      {
+        uri = "http://exception/{email}"
+        use-ssl-factory = false
+        valid-on-failure = false
+      }
+    ]
+  }
+  http-multiple-200 {
+    enabled = true
+    cache-ttl = "1d"
+    uris = [
+      {
+        uri = "http://404/{email}"
+        use-ssl-factory = false
+        valid-on-failure = true
+      },
+      {
+        uri = "http://200/{email}"
+        use-ssl-factory = false
+        valid-on-failure = true
+      }
+    ]
+  }
+  http-multiple-404 {
+    enabled = true
+    cache-ttl = "1d"
+    uris = [
+      {
+        uri = "http://404/{email}"
+        use-ssl-factory = false
+        valid-on-failure = true
+      },
+      {
+        uri = "http://404/{email}"
+        use-ssl-factory = false
+        valid-on-failure = true
+      }
+    ]
+  }
+  http-not-enabled {
+    enabled = false
+    cache-ttl = "1d"
+    uris = [
+      {
+        uri = "http://200/{email}"
+        use-ssl-factory = false
+        valid-on-failure = true
+      }
+    ]
+  }
+  http-empty {
+    enabled = true
+    cache-ttl = "1d"
+    uris = [
+    ]
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,6 +44,7 @@ object Dependencies {
   val aws2EC2            = "software.amazon.awssdk" % "ec2" % aws2
   val aws2SES            = "software.amazon.awssdk" % "ses" % aws2
   val aws2STS            = "software.amazon.awssdk" % "sts" % aws2
+  val caffeine           = "com.github.ben-manes.caffeine" % "caffeine" % "2.8.1"
   val equalsVerifier     = "nl.jqno.equalsverifier" % "equalsverifier" % "3.1.11"
   val eurekaClient       = "com.netflix.eureka" % "eureka-client" % eureka
   val guiceCore          = "com.google.inject" % "guice" % guice


### PR DESCRIPTION
Adds a new implementation of UserService that does an
inline call to check if an email is valid. This works
for the newer API internally and avoids the need to
cache the full set of users.

To reduce the cost of repeated checks it will cache
the result of checks for a period of time. Set to a
smaller value to be more responsive to new addresses.

The behavior can also be customized for a failure to
talk to the remote service. If it is a nice to have
check, then it might be better to treat it as valid
until it can be confirmed. Otherwise, an outage of
the remote service will prevent validation unless the
result has already been cached.