### PR TITLE
deprecate the Eureka client integration

### DIFF
--- a/iep-module-eureka/README.md
+++ b/iep-module-eureka/README.md
@@ -1,6 +1,8 @@
 
 ## Description
 
+> :warning: **Deprecated:** internally at Netflix, use Shrimpi instead.
+
 Guice module to configure [eureka](https://github.com/Netflix/eureka). It will do the following:
 
 * Setup binding so you can inject `ApplicationInfoManager` and `DiscoveryClient`.

--- a/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
+++ b/iep-module-eureka/src/main/java/com/netflix/iep/eureka/EurekaModule.java
@@ -43,7 +43,11 @@ import javax.inject.Singleton;
 
 /**
  * Setup eureka and create binding for DiscoveryClient.
+ *
+ * @deprecated Move to some other solution. Internally at Netflix, Shrimpi can be used
+ * if heart-beating is all that is required.
  */
+@Deprecated
 public final class EurekaModule extends AbstractModule {
 
   private static class OptionalInjections {


### PR DESCRIPTION
For Insight we only use Eureka for heart-beats and their
are simpler solutions with less overhead now.