### PR TITLE
add support for SES configuration sets

### DIFF
--- a/iep-ses/src/main/java/com/netflix/iep/ses/EmailHeader.java
+++ b/iep-ses/src/main/java/com/netflix/iep/ses/EmailHeader.java
@@ -101,6 +101,11 @@ class EmailHeader {
     return new EmailHeader("Subject", EncodingUtils.wrapBase64(subject, "Subject: ".length(), 50));
   }
 
+  /** SES configuration set header. */
+  static EmailHeader configSet(String name) {
+    return new EmailHeader("X-SES-CONFIGURATION-SET", name);
+  }
+
   private final String name;
   private final String value;
 

--- a/iep-ses/src/main/java/com/netflix/iep/ses/EmailRequestBuilder.java
+++ b/iep-ses/src/main/java/com/netflix/iep/ses/EmailRequestBuilder.java
@@ -70,6 +70,7 @@ public final class EmailRequestBuilder {
   private List<String> ccAddresses;
   private List<String> bccAddresses;
   private List<String> replyToAddresses;
+  private String configSet;
   private String subject;
   private String contentType;
   private String body;
@@ -138,6 +139,16 @@ public final class EmailRequestBuilder {
    */
   public EmailRequestBuilder withBccAddresses(String... addresses) {
     this.bccAddresses = Arrays.asList(addresses);
+    return this;
+  }
+
+  /**
+   * Specifies an SES configuration set to use for the message.
+   *
+   * @see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets.html">configuration sets</a>
+   */
+  public EmailRequestBuilder withConfigSet(String configSet) {
+    this.configSet = configSet;
     return this;
   }
 
@@ -230,6 +241,10 @@ public final class EmailRequestBuilder {
 
     if (fromArn != null && !fromArn.isEmpty()) {
       builder.append(EmailHeader.fromArn(fromArn));
+    }
+
+    if (configSet != null && !configSet.isEmpty()) {
+      builder.append(EmailHeader.configSet(configSet));
     }
 
     builder

--- a/iep-ses/src/test/java/com/netflix/iep/ses/EmailRequestBuilderTest.java
+++ b/iep-ses/src/test/java/com/netflix/iep/ses/EmailRequestBuilderTest.java
@@ -252,4 +252,14 @@ public class EmailRequestBuilderTest {
         .withTextBody("Body of the email message.");
     builder.toString();
   }
+
+  @Test
+  public void sesConfigSet() throws IOException {
+    checkMessage("sesConfigSet", new EmailRequestBuilder()
+        .withFromAddress(FROM)
+        .withToAddresses(TO)
+        .withConfigSet("emailTracking")
+        .withSubject("Test message")
+        .withHtmlBody("Repo <a href=\"https://github.com/Netflix/iep/\">repo</a>."));
+  }
 }

--- a/iep-ses/src/test/resources/sesConfigSet
+++ b/iep-ses/src/test/resources/sesConfigSet
@@ -1,0 +1,14 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+  boundary="331239ab-8a31-4cc6-84d6-5557f96ebc3a"
+From: bob@example.com
+To: andrew@example.com
+Subject: =?UTF-8?B?VGVzdCBtZXNzYWdl?=
+X-SES-CONFIGURATION-SET: emailTracking
+
+--331239ab-8a31-4cc6-84d6-5557f96ebc3a
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: base64
+
+UmVwbyA8YSBocmVmPSJodHRwczovL2dpdGh1Yi5jb20vTmV0ZmxpeC9pZXAvIj5yZXBvPC9hPi4=
+--331239ab-8a31-4cc6-84d6-5557f96ebc3a--


### PR DESCRIPTION
The builder now has a method to add the header
for specifying the configuration set name.

Fixes #440