### PR TITLE
update servergroups library to support sharding

### DIFF
--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/ServerGroup.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/ServerGroup.java
@@ -44,6 +44,8 @@ public final class ServerGroup {
   private final String group;
   private final String stack;
   private final String detail;
+  private final String shard1;
+  private final String shard2;
 
   private final int minSize;
   private final int maxSize;
@@ -62,6 +64,8 @@ public final class ServerGroup {
     group = builder.group;
     stack = sg.stack();
     detail = sg.detail();
+    shard1 = sg.shard1();
+    shard2 = sg.shard2();
 
     minSize = builder.minSize;
     maxSize = builder.maxSize;
@@ -121,6 +125,22 @@ public final class ServerGroup {
    */
   public String getDetail() {
     return detail;
+  }
+
+  /**
+   * Return the value for the first shard extracted from the detail of the server group based
+   * on the ShardingNamingConvention in Frigga.
+   */
+  public String getShard1() {
+    return shard1;
+  }
+
+  /**
+   * Return the value for the second shard extracted from the detail of the server group based
+   * on the ShardingNamingConvention in Frigga.
+   */
+  public String getShard2() {
+    return shard2;
   }
 
   /** Return the minimum size for the group. */
@@ -207,13 +227,15 @@ public final class ServerGroup {
         Objects.equals(group, that.group) &&
         Objects.equals(stack, that.stack) &&
         Objects.equals(detail, that.detail) &&
+        Objects.equals(shard1, that.shard1) &&
+        Objects.equals(shard2, that.shard2) &&
         Objects.equals(instances, that.instances);
   }
 
   @Override public int hashCode() {
     return Objects.hash(
         id, platform,
-        app, cluster, group, stack, detail,
+        app, cluster, group, stack, detail, shard1, shard2,
         minSize, maxSize, desiredSize,
         instances);
   }

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/ServerGroupTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/ServerGroupTest.java
@@ -71,6 +71,17 @@ public class ServerGroupTest {
         .build();
   }
 
+  private ServerGroup shardedGroup() {
+    return ServerGroup.builder()
+        .platform("ec2")
+        .group("app-stack-x1shard1-x2shard2-other-detail-v001")
+        .minSize(10)
+        .maxSize(100)
+        .desiredSize(42)
+        .addInstance(defaultInstance())
+        .build();
+  }
+
   @Test
   public void id() {
     Assert.assertEquals("ec2.app-stack-detail-v001", defaultGroup().getId());
@@ -104,6 +115,31 @@ public class ServerGroupTest {
   @Test
   public void detail() {
     Assert.assertEquals("detail", defaultGroup().getDetail());
+  }
+
+  @Test
+  public void shard1() {
+    Assert.assertNull(defaultGroup().getShard1());
+  }
+
+  @Test
+  public void shard2() {
+    Assert.assertNull(defaultGroup().getShard2());
+  }
+
+  @Test
+  public void shardedDetail() {
+    Assert.assertEquals("x1shard1-x2shard2-other-detail", shardedGroup().getDetail());
+  }
+
+  @Test
+  public void shardedShard1() {
+    Assert.assertEquals("shard1", shardedGroup().getShard1());
+  }
+
+  @Test
+  public void shardedShard2() {
+    Assert.assertEquals("shard2", shardedGroup().getShard2());
   }
 
   @Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val rxscala    = "0.26.5"
     val scala      = "2.12.10"
     val slf4j      = "1.7.30"
-    val spectator  = "0.104.0"
+    val spectator  = "0.106.0"
   }
 
   import Versions._

--- a/project/GitVersion.scala
+++ b/project/GitVersion.scala
@@ -6,7 +6,7 @@ import com.typesafe.sbt.SbtGit._
 object GitVersion {
 
   // Base version for master branch
-  private val baseVersion = "v2.3.x"
+  private val baseVersion = "v2.4.x"
 
   // 0.1.x
   private val versionBranch = """v?([0-9\.]+)(?:\.x)?""".r


### PR DESCRIPTION
Allows user to access shards that are specified as part
of the detail.