### PR TITLE
support dynamic override for ConfigManager

### DIFF
--- a/iep-nflxenv/src/main/java/com/netflix/iep/config/ConfigListener.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/config/ConfigListener.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.config;
+
+import com.typesafe.config.Config;
+
+import java.util.function.Consumer;
+
+/**
+ * Listener that will get invoked when the config is updated.
+ */
+@FunctionalInterface
+public interface ConfigListener {
+
+  /**
+   * Create a listener instance that will invoke the consumer when an update causes a
+   * change for the specified path.
+   *
+   * @param path
+   *     Config prefix to get from the config. If null, then the full config will be used.
+   * @param consumer
+   *     Handler that will get invoked if the update resulted in a change for the specified
+   *     path.
+   * @return
+   *     Listener instance that forwards changes for the path to the consumer.
+   */
+  static ConfigListener forPath(String path, Consumer<Config> consumer) {
+    return (previous, current) -> {
+      Config c1 = (path == null) ? previous : previous.getConfig(path);
+      Config c2 = (path == null) ? current : current.getConfig(path);
+      if (!c1.equals(c2)) {
+        consumer.accept(c2);
+      }
+    };
+  }
+
+  /**
+   * Invoked when the config is updated by a call to
+   * {@link DynamicConfigManager#setOverrideConfig(Config)}. This method will be invoked
+   * from the thread setting the override. It should be cheap to allow changes to quickly
+   * propagate to all listeners. If an exception is thrown, then a warning will be logged
+   * and the manager will move on.
+   *
+   * @param previous
+   *     Previous config instance.
+   * @param current
+   *     Current config instance with the update override applied over the base layer.
+   */
+  void onUpdate(Config previous, Config current);
+}

--- a/iep-nflxenv/src/main/java/com/netflix/iep/config/ConfigManager.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/config/ConfigManager.java
@@ -34,9 +34,21 @@ public final class ConfigManager {
 
   private static final Config CONFIG = load();
 
+  private static final DynamicConfigManager DYNAMIC = DynamicConfigManager.create(CONFIG);
+
   /** Get a cached copy of the config loaded from the default class loader. */
   public static Config get() {
     return CONFIG;
+  }
+
+  /** Get the global dynamic config manager. */
+  public static DynamicConfigManager dynamicConfigManager() {
+    return DYNAMIC;
+  }
+
+  /** Get a snapshot of the current dynamic config instance. */
+  public static Config dynamicConfig() {
+    return DYNAMIC.get();
   }
 
   /** Load config using the default class loader. */

--- a/iep-nflxenv/src/main/java/com/netflix/iep/config/DynamicConfigManager.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/config/DynamicConfigManager.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.config;
+
+import com.typesafe.config.Config;
+
+/**
+ * Base interface for a config manager that allows the base config to be updated with
+ * an override layer dynamically at runtime.
+ */
+public interface DynamicConfigManager {
+
+  /**
+   * Create a new instance of a dynamic config manager.
+   *
+   * @param baseConfig
+   *     Base config layer that will be used as a fallback to the dynamic layer.
+   * @return
+   *     Config manager instance.
+   */
+  static DynamicConfigManager create(Config baseConfig) {
+    return new DynamicConfigManagerImpl(baseConfig);
+  }
+
+  /**
+   * Returns the current config instance, i.e., override with fallback to the base config.
+   */
+  Config get();
+
+  /**
+   * Set the override config layer.
+   */
+  void setOverrideConfig(Config override);
+
+  /**
+   * Add a listener that will get invoked whenever the override config layer is updated.
+   */
+  void addListener(ConfigListener listener);
+
+  /**
+   * Remove the listener so it will no longer get invoked.
+   */
+  void removeListener(ConfigListener listener);
+}

--- a/iep-nflxenv/src/main/java/com/netflix/iep/config/DynamicConfigManagerImpl.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/config/DynamicConfigManagerImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.config;
+
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default implementation of the dynamic config manager interface.
+ */
+final class DynamicConfigManagerImpl implements DynamicConfigManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigManagerImpl.class);
+
+  private final Config baseConfig;
+  private volatile Config current;
+
+  private final Set<ConfigListener> listeners = ConcurrentHashMap.newKeySet();
+
+  /** Create a new instance. */
+  DynamicConfigManagerImpl(Config baseConfig) {
+    this.baseConfig = baseConfig;
+    this.current = baseConfig;
+  }
+
+  @Override
+  public Config get() {
+    return current;
+  }
+
+  @Override
+  public synchronized void setOverrideConfig(Config override) {
+    Config previous = current;
+    current = override.withFallback(baseConfig).resolve();
+    listeners.forEach(listener -> {
+      try {
+        listener.onUpdate(previous, current);
+      } catch (Exception e) {
+        LOGGER.warn("failed to update a listener", e);
+      }
+    });
+  }
+
+  @Override
+  public void addListener(ConfigListener listener) {
+    listeners.add(listener);
+  }
+
+  @Override
+  public void removeListener(ConfigListener listener) {
+    listeners.remove(listener);
+  }
+}

--- a/iep-nflxenv/src/test/java/com/netflix/iep/config/ConfigManagerTest.java
+++ b/iep-nflxenv/src/test/java/com/netflix/iep/config/ConfigManagerTest.java
@@ -16,6 +16,7 @@
 package com.netflix.iep.config;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,5 +62,13 @@ public class ConfigManagerTest {
     } finally {
       Thread.currentThread().setContextClassLoader(cl);
     }
+  }
+
+  @Test
+  public void dynamicConfig() {
+    Assert.assertEquals("classpath", ConfigManager.dynamicConfig().getString("iep.value"));
+    ConfigManager.dynamicConfigManager()
+        .setOverrideConfig(ConfigFactory.parseString("iep.value = \"dynamic\""));
+    Assert.assertEquals("dynamic", ConfigManager.dynamicConfig().getString("iep.value"));
   }
 }

--- a/iep-nflxenv/src/test/java/com/netflix/iep/config/DynamicConfigManagerTest.java
+++ b/iep-nflxenv/src/test/java/com/netflix/iep/config/DynamicConfigManagerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.config;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(JUnit4.class)
+public class DynamicConfigManagerTest {
+
+  private Config config(String... props) {
+    String str = String.join("\n", props);
+    return ConfigFactory.parseString(str);
+  }
+
+  private DynamicConfigManager newInstance(Config baseConfig) {
+    return DynamicConfigManager.create(baseConfig);
+  }
+
+  @Test
+  public void baseConfig() {
+    DynamicConfigManager mgr = newInstance(config("a = 1"));
+    Assert.assertEquals("1", mgr.get().getString("a"));
+  }
+
+  @Test
+  public void overrideConfig() {
+    DynamicConfigManager mgr = newInstance(config("a = 1", "b = 2"));
+    mgr.setOverrideConfig(config("a = 2", "c = 3"));
+    Assert.assertEquals("2", mgr.get().getString("a"));
+    Assert.assertEquals("2", mgr.get().getString("b"));
+    Assert.assertEquals("3", mgr.get().getString("c"));
+  }
+
+  @Test
+  public void overrideReferencesBase() {
+    DynamicConfigManager mgr = newInstance(config("a = 1"));
+    mgr.setOverrideConfig(config("b = \"test_\"${a}"));
+    Assert.assertEquals("test_1", mgr.get().getString("b"));
+  }
+
+  @Test(expected = ConfigException.UnresolvedSubstitution.class)
+  public void overrideDoesntResolve() {
+    DynamicConfigManager mgr = newInstance(config("a = 1"));
+    mgr.setOverrideConfig(config("b = \"test_\"${aa}"));
+  }
+
+  @Test
+  public void badConfigIsntUsed() {
+    DynamicConfigManager mgr = newInstance(config("a = 1"));
+    boolean failed = false;
+    try {
+      mgr.setOverrideConfig(config("b = \"test_\"${aa}", "a = 2"));
+    } catch (Exception e) {
+      failed = true;
+    }
+    Assert.assertTrue(failed);
+    Assert.assertEquals("1", mgr.get().getString("a"));
+  }
+
+  @Test
+  public void listener() {
+    AtomicInteger value = new AtomicInteger();
+    DynamicConfigManager mgr = newInstance(config("a.b = 1"));
+    mgr.addListener(ConfigListener.forPath("a", c -> value.set(c.getInt("b"))));
+    mgr.setOverrideConfig(config("a.b = 2"));
+    Assert.assertEquals(2, value.get());
+  }
+
+  @Test
+  public void listenerOnlyCalledOnChange() {
+    AtomicInteger value = new AtomicInteger();
+    DynamicConfigManager mgr = newInstance(config("a.b = 1"));
+    mgr.addListener(ConfigListener.forPath("a", c -> value.set(c.getInt("b"))));
+    mgr.setOverrideConfig(config("a.b = 1"));
+    Assert.assertEquals(0, value.get());
+  }
+
+  @Test
+  public void listenerFailureIgnored() {
+    AtomicInteger value = new AtomicInteger();
+    DynamicConfigManager mgr = newInstance(config("a.b = 1"));
+    mgr.addListener(ConfigListener.forPath("c", c -> value.addAndGet(c.getInt("b"))));
+    mgr.addListener(ConfigListener.forPath("a", c -> value.addAndGet(c.getInt("b"))));
+    mgr.setOverrideConfig(config("a.b = 2"));
+    Assert.assertEquals(2, value.get());
+  }
+
+  @Test
+  public void listenerRemove() {
+    AtomicInteger value = new AtomicInteger();
+    DynamicConfigManager mgr = newInstance(config("a.b = 1"));
+
+    ConfigListener listener = ConfigListener.forPath("a", c -> value.set(c.getInt("b")));
+    mgr.addListener(listener);
+    mgr.setOverrideConfig(config("a.b = 2"));
+    Assert.assertEquals(2, value.get());
+
+    mgr.removeListener(listener);
+    mgr.setOverrideConfig(config("a.b = 3"));
+    Assert.assertEquals(2, value.get());
+  }
+}


### PR DESCRIPTION
Adds support for setting a dynamic override layer for the
ConfigManager. This can be used for updating the config
based on runtime sources such as the command line or a
remote property service.

This should allow us to phase out the usage of the
`atlas-config` library and simplify the overall config story.