### PR TITLE
make default AdminConfig use reference.conf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val root = project.in(file("."))
 
 lazy val `iep-admin` = project
   .configure(BuildSettings.profile)
-  .dependsOn(`iep-service`)
+  .dependsOn(`iep-nflxenv`, `iep-service`)
   .settings(libraryDependencies ++= Seq(
     Dependencies.inject,
     Dependencies.jacksonCore,

--- a/iep-admin/src/main/java/com/netflix/iep/admin/AdminConfig.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/AdminConfig.java
@@ -15,6 +15,9 @@
  */
 package com.netflix.iep.admin;
 
+import com.netflix.iep.config.ConfigManager;
+import com.typesafe.config.Config;
+
 import java.time.Duration;
 
 /**
@@ -23,30 +26,25 @@ import java.time.Duration;
 public interface AdminConfig {
 
   /**
-   * Default instance of the config using fixed values. Defaults are:
-   *
-   * <pre>
-   * port          = 8077
-   * backlog       = 10
-   * shutdownDelay = PT0S
-   * uiLocation    = /ui
-   * </pre>
+   * Default instance of the config using values from reference config.
    */
   AdminConfig DEFAULT = new AdminConfig() {
+    private final Config cfg = ConfigManager.get().getConfig("netflix.iep.admin");
+
     @Override public int port() {
-      return 8077;
+      return cfg.getInt("port");
     }
 
     @Override public int backlog() {
-      return 10;
+      return cfg.getInt("backlog");
     }
 
     @Override public Duration shutdownDelay() {
-      return Duration.ZERO;
+      return cfg.getDuration("shutdown-delay");
     }
 
     @Override public String uiLocation() {
-      return "/ui";
+      return cfg.getString("ui-location");
     }
   };
 

--- a/iep-admin/src/main/resources/reference.conf
+++ b/iep-admin/src/main/resources/reference.conf
@@ -1,0 +1,7 @@
+
+netflix.iep.admin {
+  port = 8077
+  backlog = 10
+  shutdown-delay = 0s
+  ui-location = "/ui"
+}

--- a/iep-admin/src/test/java/com/netflix/iep/admin/AdminConfigTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/AdminConfigTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.admin;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+
+public class AdminConfigTest {
+
+  @Test
+  public void defaultPort() {
+    Assert.assertEquals(8077, AdminConfig.DEFAULT.port());
+  }
+
+  @Test
+  public void defaultBacklog() {
+    Assert.assertEquals(10, AdminConfig.DEFAULT.backlog());
+  }
+
+  @Test
+  public void defaultShutdownDelay() {
+    Assert.assertEquals(Duration.ZERO, AdminConfig.DEFAULT.shutdownDelay());
+  }
+
+  @Test
+  public void defaultUiLocation() {
+    Assert.assertEquals("/ui", AdminConfig.DEFAULT.uiLocation());
+  }
+}

--- a/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
+++ b/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
@@ -23,7 +23,6 @@ import com.netflix.archaius.config.EmptyConfig;
 import com.netflix.archaius.config.polling.PollingResponse;
 import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.archaius.typesafe.TypesafeConfig;
-import com.netflix.iep.admin.AdminConfig;
 import com.netflix.iep.admin.guice.AdminModule;
 import com.netflix.iep.config.ConfigManager;
 import com.netflix.spectator.api.Registry;
@@ -35,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Singleton;
 import java.net.URI;
 import java.net.URL;
-import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -71,30 +69,6 @@ public final class PlatformServiceModule extends ArchaiusModule {
   @ApplicationLayer
   protected com.netflix.archaius.api.Config providesAppConfig(final Config application) {
     return new TypesafeConfig(application);
-  }
-
-  @Provides
-  @Singleton
-  private AdminConfig providesAdminConfig(Config cfg) {
-    return new AdminConfig() {
-      @Override public int port() {
-        return cfg.getInt("netflix.iep.admin.port");
-      }
-
-      @Override public int backlog() {
-        return cfg.getInt("netflix.iep.admin.backlog");
-      }
-
-      @Override public Duration shutdownDelay() {
-        long nanos = cfg.getDuration("netflix.iep.admin.shutdown-delay", TimeUnit.NANOSECONDS);
-        return Duration.ofNanos(nanos);
-      }
-
-      @Override public String uiLocation() {
-        final String k = "netflix.iep.admin.ui-location";
-        return cfg.hasPath(k) ? cfg.getString(k) : "/ui";
-      }
-    };
   }
 
   @Override public boolean equals(Object obj) {


### PR DESCRIPTION
This allows the admin configuration to work even if the
platformservice module is not being used.