### PR TITLE
nflxenv: fallback if context classloader is null

### DIFF
--- a/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
@@ -15,15 +15,15 @@
  */
 package com.netflix.iep;
 
+import com.netflix.iep.config.ConfigManager;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 
 public class NetflixEnvironment {
   private NetflixEnvironment() {}
 
   private static final String NAMESPACE = "netflix.iep.env.";
 
-  private static final Config CONFIG = ConfigFactory.load();
+  private static final Config CONFIG = ConfigManager.get();
 
   public static String ami() {
     return CONFIG.getString(NAMESPACE + "ami");

--- a/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
+++ b/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
@@ -27,14 +27,20 @@ public class NetflixEnvironmentTest {
 
   @Test
   public void checkMethods() throws Exception {
-    for (Method method : NetflixEnvironment.class.getMethods()) {
-      if (Modifier.isStatic(method.getModifiers())) {
-        try {
-          method.invoke(null);
-        } catch (Exception e) {
-          throw new RuntimeException("failed to invoke " + method.getName(), e);
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(null);
+    try {
+      for (Method method : NetflixEnvironment.class.getMethods()) {
+        if (Modifier.isStatic(method.getModifiers())) {
+          try {
+            method.invoke(null);
+          } catch (Exception e) {
+            throw new RuntimeException("failed to invoke " + method.getName(), e);
+          }
         }
       }
+    } finally {
+      Thread.currentThread().setContextClassLoader(cl);
     }
   }
 }


### PR DESCRIPTION
For some environments where the context ClassLoader is not
set properly using NetflixEnvironment would cause:

```
Caused by: com.typesafe.config.ConfigException$BugOrBroken: Context class loader is not set for the current thread; if Thread.currentThread().getContextClassLoader() returns null, you must pass a ClassLoader explicitly to ConfigFactory.load
    at com.typesafe.config.ConfigFactory.checkedContextClassLoader(ConfigFactory.java:144)
    at com.typesafe.config.ConfigFactory.load(ConfigFactory.java:233)
    at com.netflix.iep.NetflixEnvironment.<clinit>(NetflixEnvironment.java:26)
    ... 13 more
```

This change uses `ConfigManger.get()` that checks the
context ClassLoader and falls back to the ClassLoader for
the ConfigManager class if it is not set.