### PR TITLE
ignore instances with missing fields

### DIFF
--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
@@ -103,4 +103,12 @@ public class EddaLoaderTest {
     List<ServerGroup> actual = get("edda-no-instances.json");
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void noIP() throws Exception {
+    List<ServerGroup> expected = new ArrayList<>();
+    expected.add(defaultEc2Group());
+    List<ServerGroup> actual = get("edda-noip.json");
+    Assert.assertEquals(expected, actual);
+  }
 }

--- a/iep-servergroups/src/test/resources/edda-noip.json
+++ b/iep-servergroups/src/test/resources/edda-noip.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "ec2.app-main-dev-v001",
+    "platform": "ec2",
+    "app": "app",
+    "foo": ["bar", "baz", {"abc":  ["def", {}]}],
+    "cluster": "app-main-dev",
+    "group": "app-main-dev-v001",
+    "stack": "main",
+    "detail": "dev",
+    "minSize": 1,
+    "maxSize": 3,
+    "desiredSize": 2,
+    "instances": [
+      {
+        "launchTime": 1544328558000,
+        "node": "i-1234567890",
+        "privateIpAddress": "10.20.30.40",
+        "vpcId": "vpc-54321",
+        "subnetId": "subnet-54321",
+        "ami": "ami-0987654321",
+        "vmtype": "m5.large",
+        "zone": "us-east-1d"
+      },
+      {
+        "launchTime": 1544328558000,
+        "node": "i-1234567891",
+        "vpcId": "vpc-54321",
+        "subnetId": "subnet-54321",
+        "ami": "ami-0987654321",
+        "vmtype": "m5.large",
+        "zone": "us-east-1d"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Updates the server groups helper to ignore instances
coming back in the Edda response that are missing
required fields like the privateIpAddress. This allows
other instances to update and prevents having stale
data for everything. The failure will get logged.