### PR TITLE
rename root project to iep

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-lazy val root = project.in(file("."))
+lazy val iep = project.in(file("."))
   .configure(BuildSettings.profile)
   .aggregate(
     `iep-admin`,


### PR DESCRIPTION
Makes it easier to spot in the recently used menu of the IDE.