### PR TITLE
allow rollup policy to be set with config

### DIFF
--- a/iep-module-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
+++ b/iep-module-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import com.netflix.spectator.atlas.AtlasConfig;
 import com.netflix.spectator.atlas.AtlasRegistry;
+import com.netflix.spectator.atlas.RollupPolicy;
 import com.netflix.spectator.gc.GcLogger;
 import com.netflix.spectator.jvm.Jmx;
 import com.typesafe.config.Config;
@@ -30,7 +31,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -129,6 +132,16 @@ class AtlasRegistryService extends AbstractService {
         }
       }
       return tags;
+    }
+
+    @Override public RollupPolicy rollupPolicy() {
+      List<RollupPolicy.Rule> rules = new ArrayList<>();
+      for (Config cfg : config.getConfigList("atlas.rollupPolicy")) {
+        rules.add(new RollupPolicy.Rule(cfg.getString("query"), cfg.getStringList("rollup")));
+      }
+      return rules.isEmpty()
+          ? RollupPolicy.noop(commonTags())
+          : RollupPolicy.fromRules(commonTags(), rules);
     }
 
     @Override public String validTagCharacters() {

--- a/iep-module-atlas/src/main/resources/reference.conf
+++ b/iep-module-atlas/src/main/resources/reference.conf
@@ -56,6 +56,15 @@ netflix.iep.atlas {
     }
   ]
 
+  rollupPolicy = [
+    //{
+    //  query = "name,ipc.client.call,:eq"
+    //  rollup = [
+    //    "nf.node"
+    //  ]
+    //}
+  ]
+
   collection {
     jvm = true
     gc = true

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val rxscala    = "0.26.5"
     val scala      = "2.12.10"
     val slf4j      = "1.7.30"
-    val spectator  = "0.111.0"
+    val spectator  = "0.114.0"
   }
 
   import Versions._


### PR DESCRIPTION
Updates the Atlas module to allow the rollup policy
added in Spectator 0.112.0 to be set with the config.