### PR TITLE
deprecate archaius2 module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val iep = project.in(file("."))
     `iep-module-aws`,
     `iep-module-aws2`,
     `iep-module-awsmetrics`,
+    `iep-module-dynconfig`,
     `iep-module-eureka`,
     `iep-module-jmxport`,
     `iep-module-leader`,
@@ -191,6 +192,17 @@ lazy val `iep-module-awsmetrics` = project
     Dependencies.spectatorAws,
     Dependencies.guiceCore,
     Dependencies.slf4jApi
+  ))
+
+lazy val `iep-module-dynconfig` = project
+  .configure(BuildSettings.profile)
+  .dependsOn(`iep-nflxenv`, `iep-module-admin`)
+  .settings(libraryDependencies ++= Seq(
+      Dependencies.guiceCore,
+      Dependencies.guiceMulti,
+      Dependencies.slf4jApi,
+      Dependencies.spectatorApi,
+      Dependencies.spectatorIpc
   ))
 
 lazy val `iep-module-eureka` = project

--- a/iep-config/README.md
+++ b/iep-config/README.md
@@ -1,9 +1,9 @@
 
 ## Description
 
-> :warning: **Deprecated:** For new work prefer [iep-module-archaius2][a2].
+> :warning: **Deprecated:** For new work prefer [iep-module-dynconfig][a2].
 
-[a2]: https://github.com/Netflix/iep/tree/master/iep-module-archaius2
+[a2]: https://github.com/Netflix/iep/tree/master/iep-module-dynconfig
 
 Provides a binding for archaius2. The config files support a custom scoping based on
 comment blocks.

--- a/iep-config/README.md
+++ b/iep-config/README.md
@@ -1,9 +1,9 @@
 
 ## Description
 
-> :warning: **Deprecated:** For new work prefer [iep-module-dynconfig][a2].
+> :warning: **Deprecated:** For new work prefer [iep-module-dynconfig][dynconfig].
 
-[a2]: https://github.com/Netflix/iep/tree/master/iep-module-dynconfig
+[dynconfig]: https://github.com/Netflix/iep/tree/master/iep-module-dynconfig
 
 Provides a binding for archaius2. The config files support a custom scoping based on
 comment blocks.

--- a/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius1Module.java
+++ b/iep-module-archaius1/src/main/java/com/netflix/iep/archaius1/Archaius1Module.java
@@ -30,8 +30,7 @@ import javax.inject.Singleton;
 /**
  * Helper for configuring archaius v1.
  *
- * @deprecated Move to archaius v2 or to using Typesafe Config directly. Note, Runtime support
- * for archaius v2 looks to be limited.
+ * @deprecated Move to using Typesafe Config directly.
  */
 @Deprecated
 public final class Archaius1Module extends AbstractModule {

--- a/iep-module-archaius2/README.md
+++ b/iep-module-archaius2/README.md
@@ -1,9 +1,9 @@
 
 ## Description
 
-> :warning: **Deprecated:** For new work prefer [iep-module-dynconfig][a2].
+> :warning: **Deprecated:** For new work prefer [iep-module-dynconfig][dynconfig].
 
-[a2]: https://github.com/Netflix/iep/tree/master/iep-module-dynconfig
+[dynconfig]: https://github.com/Netflix/iep/tree/master/iep-module-dynconfig
 
 Guice module to configure [archaius2](https://github.com/Netflix/archaius/tree/2.x) for use
 internally at Netflix. It will install the archaius2 guice module and put in the following

--- a/iep-module-archaius2/README.md
+++ b/iep-module-archaius2/README.md
@@ -1,6 +1,10 @@
 
 ## Description
 
+> :warning: **Deprecated:** For new work prefer [iep-module-dynconfig][a2].
+
+[a2]: https://github.com/Netflix/iep/tree/master/iep-module-dynconfig
+
 Guice module to configure [archaius2](https://github.com/Netflix/archaius/tree/2.x) for use
 internally at Netflix. It will install the archaius2 guice module and put in the following
 overrides:

--- a/iep-module-archaius2/src/main/java/com/netflix/iep/archaius2/OverrideModule.java
+++ b/iep-module-archaius2/src/main/java/com/netflix/iep/archaius2/OverrideModule.java
@@ -27,6 +27,8 @@ import com.netflix.spectator.api.Registry;
 
 /**
  * Work around for overriding the AppConfig.
+ *
+ * @deprecated Move to using Typesafe Config directly.
  */
 public final class OverrideModule extends AbstractModule {
   @Override protected void configure() {

--- a/iep-module-dynconfig/README.md
+++ b/iep-module-dynconfig/README.md
@@ -1,7 +1,7 @@
 
 ## Description
 
-Guice module to configure [iep-nflxenv] for to refresh the dynamic override layer with
+Guice module that configures [iep-nflxenv] to refresh the dynamic override layer with
 properties from [iep-archaius].
 
 [iep-nflxenv]: https://github.com/Netflix/iep/blob/master/iep-nflxenv/README.md
@@ -26,7 +26,7 @@ public class Worker {
     Config config = manager.get();
     ... use config ...
 
-    // To listen for changes to a particular properties
+    // To listen for changes to particular properties
     manager.addListener(ConfigListener.forBoolean("worker.enabled", this::enableToggled));
   }
 

--- a/iep-module-dynconfig/README.md
+++ b/iep-module-dynconfig/README.md
@@ -41,3 +41,19 @@ The DynamicConfigManager can also be accessed statically by calling
 `ConfigManager.dynamicConfigManager()`, however, it is not recommended because there is no
 guarantee the override layer will be loaded for the first time prior to use. This can cause
 strange behavior on start-up if the remote properties are necessary to function properly.
+
+## Config Precedence
+
+The configuration will have the following layers:
+
+* `ConfigManager.get()`: this is the base layer and will be similar to using the normal
+  `ConfigFactory.load()` only with some care taken about the class loader that is used. It
+  will also honor the `netflix.iep.include` setting to load some additional context specific
+  config files.
+* Remote Properties: the properties returned by the remote service other than
+  `netflix.iep.override`. These are used for simple properties where the value can be encoded
+  as a string.
+* `netflix.iep.override`: special key in the remote properties where the value is an arbitrary
+  config string. This allows for complex objects, lists, etc to be encoded and updated
+  dynamically. Since it is a single value it is also preferred when multiple related settings
+  are changed to ensure they are available atomically on the node.

--- a/iep-module-dynconfig/README.md
+++ b/iep-module-dynconfig/README.md
@@ -1,0 +1,43 @@
+
+## Description
+
+Guice module to configure [iep-nflxenv] for to refresh the dynamic override layer with
+properties from [iep-archaius].
+
+[iep-nflxenv]: https://github.com/Netflix/iep/blob/master/iep-nflxenv/README.md
+[iep-archaius]: https://github.com/Netflix-Skunkworks/iep-apps/tree/master/iep-archaius
+
+## Gradle
+
+```
+compile "com.netflix.iep:iep-module-dynconfig:${version_iep}"
+```
+
+## Usage
+
+To leverage dynamic properties, inject the DynamicConfigManager and use it to work with
+dynamic settings. Sample:
+
+```java
+public class Worker {
+  @Inject
+  public Worker(DynamicConfigManager manager) {
+    // To get snapshot of the current full config with dynamic overrides
+    Config config = manager.get();
+    ... use config ...
+
+    // To listen for changes to a particular properties
+    manager.addListener(ConfigListener.forBoolean("worker.enabled", this::enableToggled));
+  }
+
+  private void enableToggled(boolean enabled) {
+    // This should be thread safe
+    ... do something ...
+  }
+}
+```
+
+The DynamicConfigManager can also be accessed statically by calling
+`ConfigManager.dynamicConfigManager()`, however, it is not recommended because there is no
+guarantee the override layer will be loaded for the first time prior to use. This can cause
+strange behavior on start-up if the remote properties are necessary to function properly.

--- a/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigModule.java
+++ b/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigModule.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.dynconfig;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+import com.netflix.iep.admin.guice.AdminModule;
+import com.netflix.iep.config.ConfigManager;
+import com.netflix.iep.config.DynamicConfigManager;
+import com.netflix.iep.service.Service;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+
+/**
+ * Configures the {@link ConfigManager#dynamicConfigManager()} to update the override layer
+ * with properties from a remote property service.
+ */
+public final class DynamicConfigModule extends AbstractModule {
+
+  @Override protected void configure() {
+    Multibinder<Service> serviceBinder = Multibinder.newSetBinder(binder(), Service.class);
+    serviceBinder.addBinding().to(DynamicConfigService.class);
+
+    AdminModule.endpointsBinder(binder()).addBinding("/props").to(PropsEndpoint.class);
+  }
+
+  @Provides
+  @Singleton
+  DynamicConfigService providesDynamicConfigService(OptionalInjections opts) {
+    return new DynamicConfigService(opts.getRegistry());
+  }
+
+  @Provides
+  @Singleton
+  DynamicConfigManager providesDynamicConfigManager() {
+    return ConfigManager.dynamicConfigManager();
+  }
+
+  @Override public boolean equals(Object obj) {
+    return obj != null && getClass().equals(obj.getClass());
+  }
+
+  @Override public int hashCode() {
+    return getClass().hashCode();
+  }
+
+  private static class OptionalInjections {
+    @Inject(optional = true)
+    private Registry registry;
+
+    Registry getRegistry() {
+      if (registry == null) {
+        registry = new DefaultRegistry();
+      }
+      return registry;
+    }
+  }
+}

--- a/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigService.java
+++ b/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigService.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.dynconfig;
+
+import com.netflix.iep.config.ConfigManager;
+import com.netflix.iep.service.AbstractService;
+import com.netflix.spectator.api.Functions;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.patterns.PolledMeter;
+import com.netflix.spectator.ipc.http.HttpClient;
+import com.netflix.spectator.ipc.http.HttpResponse;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Polls the remote property service to refresh the set of dynamic properties.
+ */
+class DynamicConfigService extends AbstractService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigService.class);
+
+  private final AtomicLong lastUpdateTime;
+  private final URI uri;
+  private final long pollingInterval;
+  private final boolean syncInit;
+  private final ScheduledExecutorService executor;
+
+  @Inject
+  DynamicConfigService(Registry registry) {
+    this.lastUpdateTime = PolledMeter.using(registry)
+        .withName("iep.archaius.cacheAge")
+        .monitorValue(
+          new AtomicLong(System.currentTimeMillis()),
+          Functions.AGE);
+
+    Config config = ConfigManager.get();
+    this.uri = URI.create(config.getString("netflix.iep.archaius.url"));
+    this.pollingInterval = config.getDuration("netflix.iep.archaius.polling-interval", TimeUnit.MILLISECONDS);
+    this.syncInit = config.getBoolean("netflix.iep.archaius.sync-init");
+    this.executor = Executors.newSingleThreadScheduledExecutor(r -> {
+      Thread t = new Thread(r, "DynamicConfigService");
+      t.setDaemon(true);
+      return t;
+    });
+  }
+
+  @Override protected void startImpl() throws Exception {
+    // Wait until properties have been updated at least once
+    while (syncInit) {
+      if (update()) {
+        break;
+      } else {
+        Thread.sleep(pollingInterval);
+      }
+    }
+
+    // Schedule for regular updates
+    executor.scheduleWithFixedDelay(this::update, pollingInterval, pollingInterval, TimeUnit.MILLISECONDS);
+  }
+
+  @Override protected void stopImpl() throws Exception {
+    executor.shutdown();
+    executor.awaitTermination(1, TimeUnit.MINUTES);
+  }
+
+  /**
+   * Query remote service and update the properties. Returns true if successful.
+   */
+  boolean update() {
+    try {
+      LOGGER.debug("updating properties from {}", uri);
+
+      HttpResponse response = HttpClient.DEFAULT_CLIENT.get(uri).send();
+
+      if (response.status() == 200) {
+        try (InputStream in = new ByteArrayInputStream(response.entity())) {
+          final Properties props = new Properties();
+          props.load(in);
+
+          if (LOGGER.isTraceEnabled()) {
+            props.stringPropertyNames().forEach(
+                k -> LOGGER.trace("received property: [{}] = [{}]", k, props.getProperty(k)));
+          }
+
+          updateDynamicConfig(props);
+          lastUpdateTime.set(System.currentTimeMillis());
+        }
+      } else {
+        throw new IOException("request failed with status: " + response.status());
+      }
+
+      return true;
+    } catch (Exception e) {
+      LOGGER.warn("failed to update dynamic properties", e);
+      return false;
+    }
+  }
+
+  /**
+   * Update the {@link ConfigManager#dynamicConfigManager()} with the properties. The value
+   * for a special key {@code netflix.iep.override} will be treated as a Typesafe Config string
+   * so that all constructs can be supported. Other properties will get used directly.
+   */
+  void updateDynamicConfig(Properties props) {
+    final String overrideKey = "netflix.iep.override";
+    if (props.containsKey(overrideKey)) {
+      Config override = ConfigFactory.parseString(props.getProperty(overrideKey));
+      props.remove(overrideKey);
+      Config config = override.withFallback(ConfigFactory.parseProperties(props));
+      ConfigManager.dynamicConfigManager().setOverrideConfig(config);
+    } else {
+      Config config = ConfigFactory.parseProperties(props);
+      ConfigManager.dynamicConfigManager().setOverrideConfig(config);
+    }
+  }
+}

--- a/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/PropsEndpoint.java
+++ b/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/PropsEndpoint.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.dynconfig;
+
+import com.netflix.iep.admin.HttpEndpoint;
+import com.netflix.iep.config.DynamicConfigManager;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValue;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Summarizes properties in the Typesafe config similar to the default /env or /system
+ * endpoints.
+ */
+public class PropsEndpoint implements HttpEndpoint {
+
+  private final DynamicConfigManager manager;
+
+  @Inject
+  public PropsEndpoint(DynamicConfigManager manager) {
+    this.manager = manager;
+  }
+
+  @Override public Object get() {
+    return toMap(manager.get());
+  }
+
+  @Override public Object get(String path) {
+    return toMap(manager.get().getConfig(path));
+  }
+
+  private Map<String, String> toMap(Config config) {
+    Map<String, String> props = new TreeMap<>();
+    for (Map.Entry<String, ConfigValue> entry : config.entrySet()) {
+      String k = entry.getKey();
+      String v = config.getValue(k).unwrapped().toString();
+      if (v != null) {
+        props.put(k, v);
+      }
+    }
+    return props;
+  }
+}

--- a/iep-module-dynconfig/src/main/resources/META-INF/services/com.google.inject.Module
+++ b/iep-module-dynconfig/src/main/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.iep.dynconfig.DynamicConfigModule

--- a/iep-module-dynconfig/src/main/resources/reference.conf
+++ b/iep-module-dynconfig/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+
+netflix.iep.archaius {
+  url = "http://localhost:7101/props"
+  sync-init = true
+  polling-interval = 30s
+}

--- a/iep-module-dynconfig/src/main/resources/reference.conf
+++ b/iep-module-dynconfig/src/main/resources/reference.conf
@@ -1,6 +1,16 @@
 
 netflix.iep.archaius {
+  // Should the remote property source get polled?
+  enabled = false
+
+  // Remote URL to query for properties. If set to null, then
+  // collection will be disabled.
   url = "http://localhost:7101/props"
+
+  // Ensure that the remote config has been fetched successfully
+  // once before allowing the service to start.
   sync-init = true
+
+  // How frequently to refresh the remote properties.
   polling-interval = 30s
 }

--- a/iep-module-dynconfig/src/test/java/com/netflix/iep/dynconfig/DynamicConfigModuleTest.java
+++ b/iep-module-dynconfig/src/test/java/com/netflix/iep/dynconfig/DynamicConfigModuleTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.dynconfig;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.iep.config.ConfigManager;
+import com.netflix.iep.config.DynamicConfigManager;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DynamicConfigModuleTest {
+
+  @Test
+  public void dynamicConfigManager() {
+    Injector injector = Guice.createInjector(new DynamicConfigModule());
+    DynamicConfigManager manager = injector.getInstance(DynamicConfigManager.class);
+    Assert.assertSame(ConfigManager.dynamicConfigManager(), manager);
+  }
+
+  @Test
+  public void dynamicConfigService() throws Exception {
+    Injector injector = Guice.createInjector(new DynamicConfigModule());
+    DynamicConfigService service = injector.getInstance(DynamicConfigService.class);
+    service.start();
+    service.stop();
+  }
+}

--- a/iep-module-dynconfig/src/test/java/com/netflix/iep/dynconfig/DynamicConfigServiceTest.java
+++ b/iep-module-dynconfig/src/test/java/com/netflix/iep/dynconfig/DynamicConfigServiceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.dynconfig;
+
+import com.netflix.iep.config.ConfigManager;
+import com.netflix.iep.config.DynamicConfigManager;
+import com.netflix.spectator.api.NoopRegistry;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Properties;
+
+public class DynamicConfigServiceTest {
+
+  private final DynamicConfigManager manager = ConfigManager.dynamicConfigManager();
+
+  private DynamicConfigService newService() {
+    return new DynamicConfigService(new NoopRegistry());
+  }
+
+  @Before
+  public void before() {
+    manager.setOverrideConfig(ConfigFactory.empty());
+  }
+
+  @Test
+  public void fastProperties() {
+    Properties props = new Properties();
+    props.setProperty("iep.test.which-config", "dynamic");
+    DynamicConfigService service = newService();
+    service.updateDynamicConfig(props);
+    Assert.assertEquals("dynamic", manager.get().getString("iep.test.which-config"));
+  }
+
+  @Test
+  public void override() {
+    Properties props = new Properties();
+    props.setProperty("iep.test.which-config", "dynamic");
+    props.setProperty("a", "foo");
+    props.setProperty("netflix.iep.override", "iep.test.which-config=override\nb=[1]");
+    DynamicConfigService service = newService();
+    service.updateDynamicConfig(props);
+    Assert.assertFalse(manager.get().hasPath("netflix.iep.override"));
+    Assert.assertEquals("override", manager.get().getString("iep.test.which-config"));
+    Assert.assertEquals("foo", manager.get().getString("a"));
+    Assert.assertEquals(Collections.singletonList(1), manager.get().getIntList("b"));
+  }
+
+  @Test
+  public void overrideSubstitution() {
+    Properties props = new Properties();
+    props.setProperty("netflix.iep.override", "value=${includes.a}\"_\"${includes.b}");
+    DynamicConfigService service = newService();
+    service.updateDynamicConfig(props);
+    Assert.assertEquals("abc_def:foo", manager.get().getString("value"));
+  }
+
+  @Test
+  public void overrideComplex() {
+    Config override = ConfigFactory.parseResources("override.conf");
+    Properties props = new Properties();
+    props.setProperty("netflix.iep.override", override.root().render());
+    DynamicConfigService service = newService();
+    service.updateDynamicConfig(props);
+    Assert.assertEquals(override.getConfig("ieptest"), manager.get().getConfig("ieptest"));
+  }
+}

--- a/iep-module-dynconfig/src/test/java/com/netflix/iep/dynconfig/PropsEndpointTest.java
+++ b/iep-module-dynconfig/src/test/java/com/netflix/iep/dynconfig/PropsEndpointTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.dynconfig;
+
+import com.netflix.iep.config.ConfigManager;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+@SuppressWarnings("unchecked")
+public class PropsEndpointTest {
+
+  @Before
+  public void before() {
+    ConfigManager.dynamicConfigManager().setOverrideConfig(ConfigFactory.empty());
+  }
+
+  @Test
+  public void getAll() {
+    PropsEndpoint endpoint = new PropsEndpoint(ConfigManager.dynamicConfigManager());
+    Map<String, String> props = (Map<String, String>) endpoint.get();
+    Assert.assertEquals("app", props.get("iep.test.which-config"));
+  }
+
+  @Test
+  public void getPath() {
+    PropsEndpoint endpoint = new PropsEndpoint(ConfigManager.dynamicConfigManager());
+    Map<String, String> props = (Map<String, String>) endpoint.get("iep.test");
+    Assert.assertEquals("app", props.get("which-config"));
+  }
+}

--- a/iep-module-dynconfig/src/test/resources/a.conf
+++ b/iep-module-dynconfig/src/test/resources/a.conf
@@ -1,0 +1,3 @@
+
+includes.a = abc
+includes.b = def

--- a/iep-module-dynconfig/src/test/resources/application.conf
+++ b/iep-module-dynconfig/src/test/resources/application.conf
@@ -1,0 +1,12 @@
+
+netflix.iep.env.account-type = foo
+
+netflix.iep.archaius.sync-init=false
+
+// Test property for check to ensure application.conf is loaded as expected
+iep.test.which-config = app
+
+netflix.iep.include = ${?netflix.iep.include} [
+  "a.conf",
+  "c.conf"
+]

--- a/iep-module-dynconfig/src/test/resources/c.conf
+++ b/iep-module-dynconfig/src/test/resources/c.conf
@@ -1,0 +1,2 @@
+
+includes.b = "def:"${netflix.iep.env.account-type}

--- a/iep-module-dynconfig/src/test/resources/override.conf
+++ b/iep-module-dynconfig/src/test/resources/override.conf
@@ -1,0 +1,21 @@
+
+ieptest {
+  object {
+    string = "foo"
+    int = 42
+    duration = 4m
+  }
+
+  list = [
+    {
+      string = "string"
+      double = 42.1
+    },
+    [
+      {
+        nested = true
+      }
+    ],
+    false
+  ]
+}

--- a/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
+++ b/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
@@ -25,6 +25,7 @@ import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.archaius.typesafe.TypesafeConfig;
 import com.netflix.iep.admin.guice.AdminModule;
 import com.netflix.iep.config.ConfigManager;
+import com.netflix.iep.config.DynamicConfigManager;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Spectator;
 import com.typesafe.config.Config;
@@ -54,6 +55,12 @@ public final class PlatformServiceModule extends ArchaiusModule {
   @Singleton
   Config providesTypesafeConfig() {
     return ConfigManager.get();
+  }
+
+  @Provides
+  @Singleton
+  DynamicConfigManager providesDynamicConfigManager() {
+    return ConfigManager.dynamicConfigManager();
   }
 
   @Provides

--- a/iep-platformservice/src/test/java/com/netflix/iep/platformservice/PropertiesReaderTest.java
+++ b/iep-platformservice/src/test/java/com/netflix/iep/platformservice/PropertiesReaderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.platformservice;
+
+import com.netflix.iep.config.ConfigManager;
+import com.netflix.iep.config.DynamicConfigManager;
+import com.netflix.spectator.api.NoopRegistry;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Properties;
+
+public class PropertiesReaderTest {
+
+  private final DynamicConfigManager manager = ConfigManager.dynamicConfigManager();
+
+  private PropertiesReader newReader() {
+    try {
+      return new PropertiesReader(new NoopRegistry(), URI.create("http://not-used").toURL());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Before
+  public void before() {
+    manager.setOverrideConfig(ConfigFactory.empty());
+  }
+
+  @Test
+  public void fastProperties() {
+    Properties props = new Properties();
+    props.setProperty("iep.test.which-config", "dynamic");
+    PropertiesReader reader = newReader();
+    reader.updateDynamicConfig(props);
+    Assert.assertEquals("dynamic", manager.get().getString("iep.test.which-config"));
+  }
+
+  @Test
+  public void override() {
+    Properties props = new Properties();
+    props.setProperty("iep.test.which-config", "dynamic");
+    props.setProperty("a", "foo");
+    props.setProperty("netflix.iep.override", "iep.test.which-config=override\nb=[1]");
+    PropertiesReader reader = newReader();
+    reader.updateDynamicConfig(props);
+    Assert.assertFalse(manager.get().hasPath("netflix.iep.override"));
+    Assert.assertEquals("override", manager.get().getString("iep.test.which-config"));
+    Assert.assertEquals("foo", manager.get().getString("a"));
+    Assert.assertEquals(Collections.singletonList(1), manager.get().getIntList("b"));
+  }
+
+  @Test
+  public void overrideSubstitution() {
+    Properties props = new Properties();
+    props.setProperty("netflix.iep.override", "value=${includes.a}\"_\"${includes.b}");
+    PropertiesReader reader = newReader();
+    reader.updateDynamicConfig(props);
+    Assert.assertEquals("abc_def:foo", manager.get().getString("value"));
+  }
+}


### PR DESCRIPTION
Deprecates the archaius2 module to make the config story
more clear and just standardize on Typesafe Config.

For cases where dynamic configuration is desirable a new
module `iep-module-dynconfig` has been added that works
with the ConfigManager from `iep-nflxenv`. It uses the
same properties and formats as the old modules so it can
easily be dropped in as long as you do not rely on the
Archaius config interfaces. This module also has an admin
endpoint for `/props` so it is easy to inspect the config
from the admin interface just like before.