### PR TITLE
add jdk15 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11
     env: BINTRAY_PUBLISH=false
-  - jdk: openjdk14
+  - jdk: openjdk15
     env: BINTRAY_PUBLISH=false
 scala:
 - 2.12.11


### PR DESCRIPTION
Drop jdk14 and add jdk15 to keep ensure latest version is
tested.