### PR TITLE
add binding for config

### DIFF
--- a/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigModule.java
+++ b/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigModule.java
@@ -26,6 +26,7 @@ import com.netflix.iep.config.DynamicConfigManager;
 import com.netflix.iep.service.Service;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
+import com.typesafe.config.Config;
 
 /**
  * Configures the {@link ConfigManager#dynamicConfigManager()} to update the override layer
@@ -34,6 +35,8 @@ import com.netflix.spectator.api.Registry;
 public final class DynamicConfigModule extends AbstractModule {
 
   @Override protected void configure() {
+    bind(Config.class).toInstance(ConfigManager.get());
+
     Multibinder<Service> serviceBinder = Multibinder.newSetBinder(binder(), Service.class);
     serviceBinder.addBinding().to(DynamicConfigService.class);
 
@@ -42,8 +45,8 @@ public final class DynamicConfigModule extends AbstractModule {
 
   @Provides
   @Singleton
-  DynamicConfigService providesDynamicConfigService(OptionalInjections opts) {
-    return new DynamicConfigService(opts.getRegistry());
+  DynamicConfigService providesDynamicConfigService(OptionalInjections opts, Config config) {
+    return new DynamicConfigService(opts.getRegistry(), config);
   }
 
   @Provides

--- a/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigService.java
+++ b/iep-module-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigService.java
@@ -53,14 +53,13 @@ class DynamicConfigService extends AbstractService {
   private final ScheduledExecutorService executor;
 
   @Inject
-  DynamicConfigService(Registry registry) {
+  DynamicConfigService(Registry registry, Config config) {
     this.lastUpdateTime = PolledMeter.using(registry)
         .withName("iep.archaius.cacheAge")
         .monitorValue(
           new AtomicLong(System.currentTimeMillis()),
           Functions.AGE);
 
-    Config config = ConfigManager.get();
     this.enabled = config.getBoolean("netflix.iep.archaius.enabled");
     this.uri = URI.create(config.getString("netflix.iep.archaius.url"));
     this.pollingInterval = config.getDuration("netflix.iep.archaius.polling-interval", TimeUnit.MILLISECONDS);

--- a/iep-module-dynconfig/src/test/java/com/netflix/iep/dynconfig/DynamicConfigServiceTest.java
+++ b/iep-module-dynconfig/src/test/java/com/netflix/iep/dynconfig/DynamicConfigServiceTest.java
@@ -32,7 +32,7 @@ public class DynamicConfigServiceTest {
   private final DynamicConfigManager manager = ConfigManager.dynamicConfigManager();
 
   private DynamicConfigService newService() {
-    return new DynamicConfigService(new NoopRegistry());
+    return new DynamicConfigService(new NoopRegistry(), ConfigManager.get());
   }
 
   @Before


### PR DESCRIPTION
Before the dynconfig module would only have a binding
for the dynamic config manager, now it will also ensure
there is a binding for the base config instance.