### PR TITLE
add insightAccountId method

### DIFF
--- a/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
@@ -84,4 +84,8 @@ public class NetflixEnvironment {
   public static String accountEnv() {
     return CONFIG.getString(NAMESPACE + "account-env");
   }
+
+  public static String insightAccountId() {
+    return CONFIG.getString(NAMESPACE + "insight-account-id");
+  }
 }


### PR DESCRIPTION
We use this value often enough in our code that it should be available through the NetflixEnvironment class.