### PR TITLE
fix test case for github actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,4 +37,4 @@ jobs:
             ~/.ivy2
           key: ${{ runner.os }}-${{ hashFiles('**/*.sbt') }}
       - name: Build
-        run: cat /dev/null | project/sbt checkLicenseHeaders scalafmtCheckAll
+        run: cat /dev/null | project/sbt checkLicenseHeaders

--- a/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/EnvEndpointTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/EnvEndpointTest.java
@@ -41,7 +41,12 @@ public class EnvEndpointTest {
   public void getProperty() {
     Assume.assumeTrue(System.getenv("JAVA_HOME") != null);
     Map<String, String> map = (Map<String, String>) endpoint.get("JAVA_HOME");
-    Assert.assertEquals(1, map.size());
+    int size = (int) System.getenv()
+        .keySet()
+        .stream()
+        .filter(s -> s.startsWith("JAVA_HOME"))
+        .count();
+    Assert.assertEquals(size, map.size());
     Assert.assertEquals(System.getenv("JAVA_HOME"), map.get("JAVA_HOME"));
   }
 


### PR DESCRIPTION
There are multiple environment variables with a prefix
of `JAVA_HOME` on GitHub Actions.