### PR TITLE
log uncaught exceptions by default

### DIFF
--- a/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
+++ b/iep-guice/src/main/java/com/netflix/iep/guice/Main.java
@@ -71,6 +71,12 @@ public class Main {
   }
 
   void runImpl(String[] args, Module... additionalModules) throws Exception {
+    // Send uncaught exceptions to the expected logger. Register early as errors
+    // could get generated during startup.
+    Thread.setDefaultUncaughtExceptionHandler((thread, e) ->
+      LOGGER.error("Uncaught exception from thread {} ({})", thread.getName(), thread.getId(), e)
+    );
+
     try {
       // Setup binding for command line arguments
       Module argsModule = new AbstractModule() {


### PR DESCRIPTION
Add a handler to the generic main helper that will send
uncaught exceptions to the expected logger. Should ensure
they are not missing or sent to an unexpected place when
debugging issues.