### PR TITLE
add helper methods for common tags

### DIFF
--- a/iep-module-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
+++ b/iep-module-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
@@ -16,6 +16,7 @@
 package com.netflix.iep.atlas;
 
 import com.google.inject.Inject;
+import com.netflix.iep.NetflixEnvironment;
 import com.netflix.iep.service.AbstractService;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Registry;
@@ -122,16 +123,7 @@ class AtlasRegistryService extends AbstractService {
     }
 
     @Override public Map<String, String> commonTags() {
-      Map<String, String> tags = new HashMap<>();
-      for (Config cfg : config.getConfigList("atlas.tags")) {
-        // These are often populated by environment variables that can sometimes be empty
-        // rather than not set when missing. Empty strings are not allowed by Atlas.
-        String value = cfg.getString("value");
-        if (!value.isEmpty()) {
-          tags.put(cfg.getString("key"), cfg.getString("value"));
-        }
-      }
-      return tags;
+      return NetflixEnvironment.commonTagsForAtlas();
     }
 
     @Override public RollupPolicy rollupPolicy() {

--- a/iep-module-atlas/src/main/resources/reference.conf
+++ b/iep-module-atlas/src/main/resources/reference.conf
@@ -4,45 +4,6 @@ netflix.iep.atlas {
   step = PT1M
   uri = "http://localhost:7101/api/v1/publish"
 
-  tags = ${?netflix.iep.atlas.tags} [
-    {
-      key = "nf.app"
-      value = ${netflix.iep.env.app}
-    },
-    {
-      key = "nf.cluster"
-      value = ${netflix.iep.env.cluster}
-    },
-    {
-      key = "nf.asg"
-      value = ${netflix.iep.env.asg}
-    },
-    {
-      key = "nf.stack"
-      value = ${netflix.iep.env.stack}
-    },
-    {
-      key = "nf.region"
-      value = ${netflix.iep.env.region}
-    },
-    {
-      key = "nf.zone"
-      value = ${netflix.iep.env.zone}
-    },
-    {
-      key = "nf.vmtype"
-      value = ${netflix.iep.env.vmtype}
-    },
-    {
-      key = "nf.account"
-      value = ${netflix.iep.env.account-id}
-    },
-    {
-      key = "nf.node"
-      value = ${netflix.iep.env.instance-id}
-    }
-  ]
-
   validTagCharacters = "-._A-Za-z0-9"
 
   validTagValueCharacters = ${?netflix.iep.atlas.validTagValueCharacters} [

--- a/iep-module-atlasaggr/src/main/java/com/netflix/iep/atlasaggr/StatelessRegistryService.java
+++ b/iep-module-atlasaggr/src/main/java/com/netflix/iep/atlasaggr/StatelessRegistryService.java
@@ -16,6 +16,7 @@
 package com.netflix.iep.atlasaggr;
 
 import com.google.inject.Inject;
+import com.netflix.iep.NetflixEnvironment;
 import com.netflix.iep.service.AbstractService;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Registry;
@@ -119,16 +120,7 @@ class StatelessRegistryService extends AbstractService {
     }
 
     @Override public Map<String, String> commonTags() {
-      Map<String, String> tags = new HashMap<>();
-      for (Config cfg : config.getConfigList("stateless.tags")) {
-        // These are often populated by environment variables that can sometimes be empty
-        // rather than not set when missing. Empty strings are not allowed by Atlas.
-        String value = cfg.getString("value");
-        if (!value.isEmpty()) {
-          tags.put(cfg.getString("key"), cfg.getString("value"));
-        }
-      }
-      return tags;
+      return NetflixEnvironment.commonTagsForAtlas();
     }
   }
 }

--- a/iep-module-atlasaggr/src/main/resources/reference.conf
+++ b/iep-module-atlasaggr/src/main/resources/reference.conf
@@ -4,45 +4,6 @@ netflix.iep.atlas.stateless {
   frequency = PT5S
   uri = "http://localhost:7101/api/v4/update"
 
-  tags = ${?netflix.iep.atlas.stateless.tags} [
-    {
-      key = "nf.app"
-      value = ${netflix.iep.env.app}
-    },
-    {
-      key = "nf.cluster"
-      value = ${netflix.iep.env.cluster}
-    },
-    {
-      key = "nf.asg"
-      value = ${netflix.iep.env.asg}
-    },
-    {
-      key = "nf.stack"
-      value = ${netflix.iep.env.stack}
-    },
-    {
-      key = "nf.region"
-      value = ${netflix.iep.env.region}
-    },
-    {
-      key = "nf.zone"
-      value = ${netflix.iep.env.zone}
-    },
-    {
-      key = "nf.vmtype"
-      value = ${netflix.iep.env.vmtype}
-    },
-    {
-      key = "nf.account"
-      value = ${netflix.iep.env.account-id}
-    },
-    {
-      key = "nf.node"
-      value = ${netflix.iep.env.instance-id}
-    }
-  ]
-
   collection {
     jvm = true
     gc = true

--- a/iep-nflxenv/README.md
+++ b/iep-nflxenv/README.md
@@ -21,7 +21,7 @@ used settings are:
 | Name         | Environment Variable    | Description                       |
 |--------------|-------------------------|-----------------------------------|
 | ami          | EC2_AMI_ID              | [AWS Image ID][ami]               |
-| instance-id  | EC2_INSTANCE_ID         | AWS Instance ID                   |
+| instance-id  | NETFLIX_INSTANCE_ID     | AWS Instance ID                   |
 | region       | EC2_REGION              | [AWS Region][regions]             |
 | vmtype       | EC2_INSTANCE_TYPE       | [AWS instance type][vmtype]       |
 | zone         | EC2_AVAILABILITY_ZONE   | [AWS Availability Zone][regions]  |
@@ -34,14 +34,14 @@ used settings are:
 
 These are settings that typically get set by Netflix when the system is configured. When
 running in EC2 they are set via the user data in the launch config. All of these environment
-variables will have a prefix of `NETFLIX_` or `CLOUD_`. If both are present, then the
-`CLOUD_` prefix will get used.
+variables will have a prefix of `NETFLIX_`.
 
 | Name         | Environment Variable    | Description                                                                                     |
 |--------------|-------------------------|-------------------------------------------------------------------------------------------------|
 | account      | ACCOUNT                 | Account name, typically `$type$env`                                                             |
 | account-env  | ACCOUNT_ENV             | Should always be test or prod                                                                   |
 | account-type | ACCOUNT_TYPE            | Type of the account, usually matches the stack name of supporting services                      |
+| account-id   | ACCOUNT_ID              | Id for the account                                                                              |
 | environment  | ENVIRONMENT             | With new user data should always be test or prod. Older user data it may be the same as ACCOUNT |
 | domain       | DOMAIN                  | DNS sub domain for this environment. Used to substitute config settings with host names         |
 
@@ -60,8 +60,8 @@ foo_webapp-main-canary-v042
 
 [frigga]: https://github.com/Netflix/frigga
 
-All of these environment variables will have a prefix of `NETFLIX_` or `CLOUD_`. If both are
-present, then the `CLOUD_` prefix will get used. The property names and environment variables are:
+All of these environment variables will have a prefix of `NETFLIX_`. The property
+names and environment variables are:
 
 | Name         | Environment Variable    | Description                             |
 |--------------|-------------------------|-----------------------------------------|

--- a/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
@@ -18,6 +18,14 @@ package com.netflix.iep;
 import com.netflix.iep.config.ConfigManager;
 import com.typesafe.config.Config;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
 public class NetflixEnvironment {
   private NetflixEnvironment() {}
 
@@ -87,5 +95,193 @@ public class NetflixEnvironment {
 
   public static String insightAccountId() {
     return CONFIG.getString(NAMESPACE + "insight-account-id");
+  }
+
+  /**
+   * Set of common tag keys that should be used for metrics by default. Other contexts
+   * like logs could use a larger set that are inappropriate for use on metrics.
+   */
+  private static final Set DEFAULT_ATLAS_TAG_KEYS;
+  static {
+    Set<String> tagKeys = new HashSet<>();
+    tagKeys.add("nf.account");
+    tagKeys.add("nf.app");
+    tagKeys.add("nf.asg");
+    tagKeys.add("nf.cluster");
+    tagKeys.add("nf.node");
+    tagKeys.add("nf.region");
+    tagKeys.add("nf.shard1");
+    tagKeys.add("nf.shard2");
+    tagKeys.add("nf.stack");
+    tagKeys.add("nf.vmtype");
+    tagKeys.add("nf.zone");
+    tagKeys.add("process");
+    DEFAULT_ATLAS_TAG_KEYS = Collections.unmodifiableSet(tagKeys);
+  }
+
+  /**
+   * Extract common infrastructure tags for use with metrics, logs, etc from the
+   * Netflix environment variables.
+   *
+   * @return
+   *     Common tags based on the environment.
+   */
+  public static Map<String, String> commonTags() {
+    return commonTags(System::getenv);
+  }
+
+  /**
+   * Extract common infrastructure tags for use with metrics, logs, etc from the
+   * Netflix environment variables.
+   *
+   * @param getenv
+   *     Function used to retrieve the value of an environment variable.
+   * @return
+   *     Common tags based on the environment.
+   */
+  public static Map<String, String> commonTags(Function<String, String> getenv) {
+    // Note, these extract from the environment directly rather than use the helper
+    // methods that access the reference config. This is done because the helpers
+    // assign default values to many of the entries which can be convenient for testing,
+    // but are not appropriate for inclusion with tags.
+    Map<String, String> tags = new HashMap<>();
+
+    // Generic infrastructure
+    putIfNotEmptyOrNull(getenv, tags, "nf.account", "NETFLIX_ACCOUNT_ID");
+    putIfNotEmptyOrNull(getenv, tags, "nf.ami", "EC2_AMI_ID");
+    putIfNotEmptyOrNull(getenv, tags, "nf.app", "NETFLIX_APP");
+    putIfNotEmptyOrNull(getenv, tags, "nf.asg", "NETFLIX_AUTO_SCALE_GROUP");
+    putIfNotEmptyOrNull(getenv, tags, "nf.cluster", "NETFLIX_CLUSTER");
+    putIfNotEmptyOrNull(getenv, tags, "nf.node", "NETFLIX_INSTANCE_ID");
+    putIfNotEmptyOrNull(getenv, tags, "nf.region", "EC2_REGION");
+    putIfNotEmptyOrNull(getenv, tags, "nf.shard1", "NETFLIX_SHARD1");
+    putIfNotEmptyOrNull(getenv, tags, "nf.shard2", "NETFLIX_SHARD2");
+    putIfNotEmptyOrNull(getenv, tags, "nf.stack", "NETFLIX_STACK");
+    putIfNotEmptyOrNull(getenv, tags, "nf.vmtype", "EC2_INSTANCE_TYPE");
+    putIfNotEmptyOrNull(getenv, tags, "nf.zone", "EC2_AVAILABILITY_ZONE");
+    putIfNotEmptyOrNull(getenv, tags, "process", "NETFLIX_PROCESS_NAME");
+
+    // Build info
+    putIfNotEmptyOrNull(getenv, tags, "accountType", "NETFLIX_ACCOUNT_TYPE");
+    putIfNotEmptyOrNull(getenv, tags, "buildUrl", "NETFLIX_BUILD_JOB");
+    putIfNotEmptyOrNull(getenv, tags, "sourceRepo", "NETFLIX_BUILD_SOURCE_REPO");
+    putIfNotEmptyOrNull(getenv, tags, "branch", "NETFLIX_BUILD_BRANCH");
+    putIfNotEmptyOrNull(getenv, tags, "commit", "NETFLIX_BUILD_COMMIT");
+
+    // Mantis info
+    putIfNotEmptyOrNull(getenv, tags, "mantisJobName", "MANTIS_JOB_NAME");
+    putIfNotEmptyOrNull(getenv, tags, "mantisJobId", "MANTIS_JOB_ID");
+    putIfNotEmptyOrNull(getenv, tags, "mantisWorkerIndex", "MANTIS_WORKER_INDEX");
+    putIfNotEmptyOrNull(getenv, tags, "mantisWorkerNumber", "MANTIS_WORKER_NUMBER");
+    putIfNotEmptyOrNull(getenv, tags, "mantisWorkerStageNumber", "MANTIS_WORKER_STAGE_NUMBER");
+    putIfNotEmptyOrNull(getenv, tags, "mantisUser", "MANTIS_USER");
+
+    return tags;
+  }
+
+  /**
+   * Extract common infrastructure tags for use with Atlas metrics from the
+   * Netflix environment variables. This may be a subset of those used for other
+   * contexts like logs.
+   *
+   * @return
+   *     Common tags based on the environment.
+   */
+  public static Map<String, String> commonTagsForAtlas() {
+    return commonTagsForAtlas(System::getenv);
+  }
+
+  /**
+   * Extract common infrastructure tags for use with Atlas metrics from the
+   * Netflix environment variables. This may be a subset of those used for other
+   * contexts like logs.
+   *
+   * @param getenv
+   *     Function used to retrieve the value of an environment variable.
+   * @return
+   *     Common tags based on the environment.
+   */
+  public static Map<String, String> commonTagsForAtlas(Function<String, String> getenv) {
+    return commonTagsForAtlas(getenv, defaultAtlasKeyPredicate(getenv));
+  }
+
+  /**
+   * Extract common infrastructure tags for use with Atlas metrics from the
+   * Netflix environment variables. This may be a subset of those used for other
+   * contexts like logs.
+   *
+   * @param getenv
+   *     Function used to retrieve the value of an environment variable.
+   * @param keyPredicate
+   *     Predicate to determine if a common tag key should be included as part of
+   *     the Atlas tags.
+   * @return
+   *     Common tags based on the environment.
+   */
+  public static Map<String, String> commonTagsForAtlas(
+      Function<String, String> getenv, Predicate<String> keyPredicate) {
+    Map<String, String> tags = commonTags(getenv);
+    tags.keySet().removeIf(keyPredicate.negate());
+    return tags;
+  }
+
+  /**
+   * Returns the recommended predicate to use for filtering out the set of common tags
+   * to the set that should be used on Atlas metrics.
+   *
+   * @param getenv
+   *     Function used to retrieve the value of an environment variable.
+   * @return
+   *     Predicate that evaluates to true if a tag key should be included.
+   */
+  public static Predicate<String> defaultAtlasKeyPredicate(Function<String, String> getenv) {
+    Predicate<String> skipPredicate = atlasSkipTagsPredicate(getenv);
+    return k -> DEFAULT_ATLAS_TAG_KEYS.contains(k) && skipPredicate.test(k);
+  }
+
+
+  /**
+   * Returns the recommended predicate to use for skipping common tags based on the
+   * {@code ATLAS_SKIP_COMMON_TAGS} environment variable.
+   *
+   * @param getenv
+   *     Function used to retrieve the value of an environment variable.
+   * @return
+   *     Predicate that evaluates to true if a tag key should be included.
+   */
+  public static Predicate<String> atlasSkipTagsPredicate(Function<String, String> getenv) {
+    Set<String> tagsToSkip = parseAtlasSkipTags(getenv);
+    return k -> !tagsToSkip.contains(k);
+  }
+
+  private static boolean isEmptyOrNull(String s) {
+    return s == null || s.trim().isEmpty();
+  }
+
+  private static void putIfNotEmptyOrNull(
+      Function<String, String> getenv, Map<String, String> tags, String key, String envVar) {
+    String value = getenv.apply(envVar);
+    if (!isEmptyOrNull(value)) {
+      tags.put(key, value.trim());
+    }
+  }
+
+  private static Set<String> parseAtlasSkipTags(Function<String, String> getenv) {
+    return parseAtlasSkipTags(getenv.apply("ATLAS_SKIP_COMMON_TAGS"));
+  }
+
+  private static Set<String> parseAtlasSkipTags(String skipTags) {
+    if (isEmptyOrNull(skipTags)) {
+      return Collections.emptySet();
+    } else {
+      Set<String> set = new HashSet<>();
+      String[] parts = skipTags.split(",");
+      for (String s : parts) {
+        if (!isEmptyOrNull(s)) {
+          set.add(s.trim());
+        }
+      }
+      return set;
+    }
   }
 }

--- a/iep-nflxenv/src/main/resources/reference.conf
+++ b/iep-nflxenv/src/main/resources/reference.conf
@@ -19,7 +19,7 @@ netflix.iep.env {
   region = ${?EC2_REGION}
 
   instance-id = "localhost"
-  instance-id = ${?EC2_INSTANCE_ID}
+  instance-id = ${?NETFLIX_INSTANCE_ID}
 
   local-ip = "127.0.0.1"
   local-ip = ${?EC2_LOCAL_IPV4}
@@ -29,51 +29,41 @@ netflix.iep.env {
   host = ${?EC2_PUBLIC_HOSTNAME}
 
   account-id = "unknown"
-  account-id = ${?EC2_OWNER_ID}
+  account-id = ${?NETFLIX_ACCOUNT_ID}
 
   account = "test"
   account = ${?NETFLIX_ACCOUNT}
-  account = ${?CLOUD_ACCOUNT}
   account-env = "test"
   account-env = ${?NETFLIX_ENVIRONMENT}
-  account-env = ${?CLOUD_ENVIRONMENT}
   account-env = ${?NETFLIX_ACCOUNT_ENV}
-  account-env = ${?CLOUD_ACCOUNT_ENV}
   account-type = "main"
   account-type = ${?NETFLIX_ACCOUNT_TYPE}
-  account-type = ${?CLOUD_ACCOUNT_TYPE}
 
   // If you need to use this field, install the pluggable-accounts package.
   insight-account-id = "unknown"
-  insight-account-id = ${?EC2_OWNER_ID}
+  insight-account-id = ${?NETFLIX_ACCOUNT_ID}
   insight-account-id = ${?INSIGHT_ACCOUNT_ID}
 
   // With newer user data this should only ever be "test" or "prod". In most cases
   // account-env should be preferred.
   environment = "test"
   environment = ${?NETFLIX_ENVIRONMENT}
-  environment = ${?CLOUD_ENVIRONMENT}
 
   domain = "localhost"
   domain = ${?NETFLIX_DOMAIN}
-  domain = ${?CLOUD_DOMAIN}
 
   vpc-id = "classic"
   vpc-id = ${?EC2_VPC_ID}
 
   app = "local"
   app = ${?NETFLIX_APP}
-  app = ${?CLOUD_APP}
 
   cluster = "local-dev"
   cluster = ${?NETFLIX_CLUSTER}
-  cluster = ${?CLOUD_CLUSTER}
 
   asg = "local-dev"
   asg = ${?NETFLIX_AUTO_SCALE_GROUP}
-  asg = ${?CLOUD_AUTO_SCALE_GROUP}
 
   stack = "dev"
   stack = ${?NETFLIX_STACK}
-  stack = ${?CLOUD_STACK}
 }


### PR DESCRIPTION
Adds methods to NetflixEnvironment helper for extracting
common tags from environment variables. Both of the Atlas
modules now use these helpers to ensure the common tag
behavior will be the same.