### PR TITLE
sign jars when publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,13 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/*.sbt') }}
       - name: Build
         env:
-          sonatypeUser: ${{ secrets.ORG_SONATYPE_USERNAME }}
-          sonatypePassword: ${{ secrets.ORG_SONATYPE_PASSWORD }}
+          NETFLIX_OSS_REPO_USERNAME: ${{ secrets.ORG_NETFLIXOSS_USERNAME }}
+          NETFLIX_OSS_REPO_PASSWORD: ${{ secrets.ORG_NETFLIXOSS_PASSWORD }}
+          NETFLIX_OSS_SONATYPE_USERNAME: ${{ secrets.ORG_SONATYPE_USERNAME }}
+          NETFLIX_OSS_SONATYPE_PASSWORD: ${{ secrets.ORG_SONATYPE_PASSWORD }}
+          PGP_SECRET: ${{ secrets.ORG_SIGNING_KEY }}
+          PGP_PASSPHRASE: ${{ secrets.ORG_SIGNING_PASSWORD }}
         run: |
           git fetch --unshallow --tags
-          cat /dev/null | project/sbt clean test publish
+          cat /dev/null | project/sbt clean test publishSigned
           cat /dev/null | project/sbt sonatypeBundleRelease

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,8 +22,12 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/*.sbt') }}
       - name: Build
         env:
-          sonatypeUser: ${{ secrets.ORG_SONATYPE_USERNAME }}
-          sonatypePassword: ${{ secrets.ORG_SONATYPE_PASSWORD }}
+          NETFLIX_OSS_REPO_USERNAME: ${{ secrets.ORG_NETFLIXOSS_USERNAME }}
+          NETFLIX_OSS_REPO_PASSWORD: ${{ secrets.ORG_NETFLIXOSS_PASSWORD }}
+          NETFLIX_OSS_SONATYPE_USERNAME: ${{ secrets.ORG_SONATYPE_USERNAME }}
+          NETFLIX_OSS_SONATYPE_PASSWORD: ${{ secrets.ORG_SONATYPE_PASSWORD }}
+          PGP_SECRET: ${{ secrets.ORG_SIGNING_KEY }}
+          PGP_PASSPHRASE: ${{ secrets.ORG_SIGNING_PASSWORD }}
         run: |
           git fetch --unshallow --tags
-          cat /dev/null | project/sbt clean test publish
+          cat /dev/null | project/sbt clean test publishSigned

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -55,8 +55,8 @@ object BuildSettings {
 
   val resolvers = Seq(
     Resolver.mavenLocal,
-    Resolver.jcenterRepo,
-    "jfrog" at "https://oss.jfrog.org/oss-snapshot-local")
+    Resolver.mavenCentral
+  )
 
   // Don't create root.jar, from:
   // http://stackoverflow.com/questions/20747296/producing-no-artifact-for-root-project-with-package-under-multi-project-build-in

--- a/project/SonatypeSettings.scala
+++ b/project/SonatypeSettings.scala
@@ -5,14 +5,12 @@ import xerial.sbt.Sonatype.SonatypeKeys._
 
 object SonatypeSettings {
 
-  lazy val now = System.currentTimeMillis
-
   private def get(k: String): String = {
-    sys.env.getOrElse(s"sonatype$k", s"missing$k")
+    sys.env.getOrElse(s"NETFLIX_OSS_SONATYPE_$k", s"missing$k")
   }
 
-  lazy val user = get("User")
-  lazy val pass = get("Password")
+  private lazy val user = get("USERNAME")
+  private lazy val pass = get("PASSWORD")
 
   lazy val settings: Seq[Def.Setting[_]] = sonatypeSettings ++ Seq(
     sonatypeProfileName := "com.netflix",


### PR DESCRIPTION
Update the env variables used for the actions to be more
consistent with gradle projects. For the PGP keys the env
variables expected by `sbt-pgp` are used.