### PR TITLE
add fallbacks to legacy env variables

### DIFF
--- a/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
@@ -147,12 +147,17 @@ public class NetflixEnvironment {
     Map<String, String> tags = new HashMap<>();
 
     // Generic infrastructure
-    putIfNotEmptyOrNull(getenv, tags, "nf.account", "NETFLIX_ACCOUNT_ID");
+    putIfNotEmptyOrNull(getenv, tags, "nf.account",
+        "NETFLIX_ACCOUNT_ID",
+        "EC2_OWNER_ID");
     putIfNotEmptyOrNull(getenv, tags, "nf.ami", "EC2_AMI_ID");
     putIfNotEmptyOrNull(getenv, tags, "nf.app", "NETFLIX_APP");
     putIfNotEmptyOrNull(getenv, tags, "nf.asg", "NETFLIX_AUTO_SCALE_GROUP");
     putIfNotEmptyOrNull(getenv, tags, "nf.cluster", "NETFLIX_CLUSTER");
-    putIfNotEmptyOrNull(getenv, tags, "nf.node", "NETFLIX_INSTANCE_ID");
+    putIfNotEmptyOrNull(getenv, tags, "nf.node",
+        "NETFLIX_INSTANCE_ID",
+        "TITUS_TASK_INSTANCE_ID",
+        "EC2_INSTANCE_ID");
     putIfNotEmptyOrNull(getenv, tags, "nf.region", "EC2_REGION");
     putIfNotEmptyOrNull(getenv, tags, "nf.shard1", "NETFLIX_SHARD1");
     putIfNotEmptyOrNull(getenv, tags, "nf.shard2", "NETFLIX_SHARD2");
@@ -259,10 +264,13 @@ public class NetflixEnvironment {
   }
 
   private static void putIfNotEmptyOrNull(
-      Function<String, String> getenv, Map<String, String> tags, String key, String envVar) {
-    String value = getenv.apply(envVar);
-    if (!isEmptyOrNull(value)) {
-      tags.put(key, value.trim());
+      Function<String, String> getenv, Map<String, String> tags, String key, String... envVars) {
+    for (String envVar : envVars) {
+      String value = getenv.apply(envVar);
+      if (!isEmptyOrNull(value)) {
+        tags.put(key, value.trim());
+        break;
+      }
     }
   }
 

--- a/iep-nflxenv/src/main/resources/reference.conf
+++ b/iep-nflxenv/src/main/resources/reference.conf
@@ -19,6 +19,8 @@ netflix.iep.env {
   region = ${?EC2_REGION}
 
   instance-id = "localhost"
+  instance-id = ${?EC2_INSTANCE_ID}
+  instance-id = ${?TITUS_TASK_INSTANCE_ID}
   instance-id = ${?NETFLIX_INSTANCE_ID}
 
   local-ip = "127.0.0.1"
@@ -29,6 +31,7 @@ netflix.iep.env {
   host = ${?EC2_PUBLIC_HOSTNAME}
 
   account-id = "unknown"
+  account-id = ${?EC2_OWNER_ID}
   account-id = ${?NETFLIX_ACCOUNT_ID}
 
   account = "test"

--- a/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
+++ b/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
@@ -196,4 +196,46 @@ public class NetflixEnvironmentTest {
     Map<String, String> actual = NetflixEnvironment.commonTagsForAtlas(vars::get);
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void commonTagsFallbackToOwnerId() {
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("EC2_OWNER_ID", vars.get("NETFLIX_ACCOUNT_ID"));
+    vars.remove("NETFLIX_ACCOUNT_ID");
+    Map<String, String> expected = sampleExpectedTags();
+    Map<String, String> actual = NetflixEnvironment.commonTags(vars::get);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void commonTagsFallbackToTitusTaskId() {
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("TITUS_TASK_INSTANCE_ID", vars.get("NETFLIX_INSTANCE_ID"));
+    vars.remove("NETFLIX_INSTANCE_ID");
+    Map<String, String> expected = sampleExpectedTags();
+    Map<String, String> actual = NetflixEnvironment.commonTags(vars::get);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void commonTagsFallbackToEc2InstanceId() {
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("EC2_INSTANCE_ID", vars.get("NETFLIX_INSTANCE_ID"));
+    vars.remove("NETFLIX_INSTANCE_ID");
+    Map<String, String> expected = sampleExpectedTags();
+    Map<String, String> actual = NetflixEnvironment.commonTags(vars::get);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void commonTagsTitusOverridesEc2InstanceId() {
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("EC2_INSTANCE_ID", vars.get("NETFLIX_INSTANCE_ID"));
+    vars.put("TITUS_TASK_INSTANCE_ID", "titus-12345");
+    vars.remove("NETFLIX_INSTANCE_ID");
+    Map<String, String> expected = sampleExpectedTags();
+    expected.put("nf.node", "titus-12345");
+    Map<String, String> actual = NetflixEnvironment.commonTags(vars::get);
+    Assert.assertEquals(expected, actual);
+  }
 }


### PR DESCRIPTION
If users update in place they may not have the newer
environment available. For `nf.account` and `nf.node`
this change will fallback to the older versions.