### PR TITLE
use global region for route53

### DIFF
--- a/iep-module-aws2/src/main/resources/reference.conf
+++ b/iep-module-aws2/src/main/resources/reference.conf
@@ -43,15 +43,33 @@ netflix.iep.aws {
     }
 
     route53 {
-      us-east-1 = us-east-1
-      us-west-2 = us-east-1
-      us-west-1 = us-east-1
-      eu-west-1 = us-east-1
-      eu-central-1 = us-east-1
-      ap-southeast-1 = us-east-1
-      ap-southeast-2 = us-east-1
-      ap-northeast-1 = us-east-1
-      sa-east-1 = us-east-1
+      // https://github.com/aws/aws-sdk-java-v2/issues/456
+      af-south-1 = aws-global
+      ap-east-1 = aws-global
+      ap-northeast-1 = aws-global
+      ap-northeast-2 = aws-global
+      ap-south-1 = aws-global
+      ap-southeast-1 = aws-global
+      ap-southeast-2 = aws-global
+      ca-central-1 = aws-global
+      cn-north-1 = aws-global
+      cn-northwest-1 = aws-global
+      eu-central-1 = aws-global
+      eu-north-1 = aws-global
+      eu-south-1 = aws-global
+      eu-west-1 = aws-global
+      eu-west-2 = aws-global
+      eu-west-3 = aws-global
+      me-south-1 = aws-global
+      sa-east-1 = aws-global
+      us-east-1 = aws-global
+      us-east-2 = aws-global
+      us-gov-east-1 = aws-global
+      us-gov-west-1 = aws-global
+      us-iso-east-1 = aws-global
+      us-isob-east-1 = aws-global
+      us-west-1 = aws-global
+      us-west-2 = aws-global
     }
 
     simpleemail {


### PR DESCRIPTION
Add overrides to default config to use the global
region for route53 calls. This is required for the
V2 SDK.