### PR TITLE
prefer NETFLIX_REGION over EC2_REGION

### DIFF
--- a/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
@@ -158,7 +158,9 @@ public class NetflixEnvironment {
         "NETFLIX_INSTANCE_ID",
         "TITUS_TASK_INSTANCE_ID",
         "EC2_INSTANCE_ID");
-    putIfNotEmptyOrNull(getenv, tags, "nf.region", "EC2_REGION");
+    putIfNotEmptyOrNull(getenv, tags, "nf.region",
+        "NETFLIX_REGION",
+        "EC2_REGION");
     putIfNotEmptyOrNull(getenv, tags, "nf.shard1", "NETFLIX_SHARD1");
     putIfNotEmptyOrNull(getenv, tags, "nf.shard2", "NETFLIX_SHARD2");
     putIfNotEmptyOrNull(getenv, tags, "nf.stack", "NETFLIX_STACK");

--- a/iep-nflxenv/src/main/resources/reference.conf
+++ b/iep-nflxenv/src/main/resources/reference.conf
@@ -17,6 +17,7 @@ netflix.iep.env {
 
   region = "us-east-1"
   region = ${?EC2_REGION}
+  region = ${?NETFLIX_REGION}
 
   instance-id = "localhost"
   instance-id = ${?EC2_INSTANCE_ID}

--- a/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
+++ b/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
@@ -55,7 +55,7 @@ public class NetflixEnvironmentTest {
     vars.put("NETFLIX_AUTO_SCALE_GROUP", "foo-bar-s1abc-s2def-v001");
     vars.put("NETFLIX_CLUSTER", "foo-bar-s1abc-s2def");
     vars.put("NETFLIX_INSTANCE_ID", "i-12345");
-    vars.put("EC2_REGION", "us-east-1");
+    vars.put("NETFLIX_REGION", "us-east-1");
     vars.put("NETFLIX_SHARD1", "abc");
     vars.put("NETFLIX_SHARD2", "def");
     vars.put("NETFLIX_STACK", "bar");
@@ -194,6 +194,16 @@ public class NetflixEnvironmentTest {
     vars.put("ATLAS_SKIP_COMMON_TAGS", "");
     Map<String, String> expected = atlasExpectedTags();
     Map<String, String> actual = NetflixEnvironment.commonTagsForAtlas(vars::get);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void commonTagsFallbackToEc2Region() {
+    Map<String, String> vars = sampleEnvironmentVars();
+    vars.put("EC2_REGION", vars.get("NETFLIX_REGION"));
+    vars.remove("NETFLIX_REGION");
+    Map<String, String> expected = sampleExpectedTags();
+    Map<String, String> actual = NetflixEnvironment.commonTags(vars::get);
     Assert.assertEquals(expected, actual);
   }
 


### PR DESCRIPTION
This is a newer more generic variable and should be
preferred if present.