### PR TITLE
deprecate AWS and RxNetty modules

### DIFF
--- a/iep-module-aws/src/main/java/com/netflix/iep/aws/AwsClientFactory.java
+++ b/iep-module-aws/src/main/java/com/netflix/iep/aws/AwsClientFactory.java
@@ -38,7 +38,10 @@ import java.util.function.Function;
 
 /**
  * Factory for creating instances of AWS clients.
+ *
+ * @deprecated Migrate to AWS SDK for Java V2 ({@code iep-module-aws2}).
  */
+@Deprecated
 @Singleton
 public class AwsClientFactory implements AutoCloseable {
 

--- a/iep-module-aws/src/main/java/com/netflix/iep/aws/AwsModule.java
+++ b/iep-module-aws/src/main/java/com/netflix/iep/aws/AwsModule.java
@@ -25,7 +25,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Creates a binding for an {@link AwsClientFactory}.
+ *
+ * @deprecated Migrate to AWS SDK for Java V2 ({@code iep-module-aws2}).
  */
+@Deprecated
 public final class AwsModule extends AbstractModule {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AwsModule.class);

--- a/iep-module-aws/src/main/java/com/netflix/iep/aws/Pagination.java
+++ b/iep-module-aws/src/main/java/com/netflix/iep/aws/Pagination.java
@@ -30,7 +30,11 @@ import java.util.function.Function;
 
 /**
  * Helper for paginating AWS requests.
+ *
+ * @deprecated Migrate to AWS SDK for Java V2 ({@code iep-module-aws2}). The V2 SDK
+ * supports pagination automatically.
  */
+@Deprecated
 public final class Pagination {
 
   private Pagination() {

--- a/iep-module-awsmetrics/src/main/java/com/netflix/iep/awsmetrics/AwsMetricsModule.java
+++ b/iep-module-awsmetrics/src/main/java/com/netflix/iep/awsmetrics/AwsMetricsModule.java
@@ -26,6 +26,12 @@ import com.netflix.spectator.aws.SpectatorMetricCollector;
 
 import javax.inject.Singleton;
 
+/**
+ * @deprecated Migrate to AWS SDK for Java V2. The {@code spectator-ext-aws2} library
+ * can be used and will be loaded automatically by the V2 SDK if it is present on the
+ * classpath.
+ */
+@Deprecated
 public final class AwsMetricsModule extends AbstractModule {
 
   @Override protected void configure() {

--- a/iep-module-rxnetty/src/main/java/com/netflix/iep/rxnetty/RxNettyModule.java
+++ b/iep-module-rxnetty/src/main/java/com/netflix/iep/rxnetty/RxNettyModule.java
@@ -29,7 +29,11 @@ import com.netflix.iep.http.ServerRegistry;
 
 import javax.inject.Singleton;
 
-
+/**
+ * @deprecated RxNetty is deprecated and no longer maintained. Move to a supported
+ * networking library.
+ */
+@Deprecated
 public final class RxNettyModule extends AbstractModule {
 
   private static class OptionalInjections {

--- a/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
+++ b/iep-platformservice/src/main/java/com/netflix/iep/platformservice/PlatformServiceModule.java
@@ -40,7 +40,10 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Helper for configuring archaius with the Netflix dynamic property source.
+ *
+ * @deprecated Archaius is deprecated. Migrate to {@code iep-module-dynconfig}.
  */
+@Deprecated
 public final class PlatformServiceModule extends ArchaiusModule {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PlatformServiceModule.class);


### PR DESCRIPTION
Deprecate the main classes for:

- iep-module-aws
- iep-module-awsmetrics
- iep-module-rxnetty
- iep-platformservice

These modules will be removed for 3.0.