### PR TITLE
fix build deprecation warnings

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -28,22 +28,22 @@ object BuildSettings {
     scalaVersion := Dependencies.Versions.scala,
     scalacOptions ++= BuildSettings.compilerFlags,
     javacOptions ++= BuildSettings.javaCompilerFlags,
-    javacOptions in doc := BuildSettings.javadocFlags,
+    doc / javacOptions := BuildSettings.javadocFlags,
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     crossPaths := false,
     sourcesInBase := false,
-    fork in Test := true,
+    Test / fork := true,
     autoScalaLibrary := false,
     externalResolvers := BuildSettings.resolvers,
 
     // Evictions: https://github.com/sbt/sbt/issues/1636
     // Linting: https://github.com/sbt/sbt/pull/5153
-    (evictionWarningOptions in update).withRank(KeyRanks.Invisible) := EvictionWarningOptions.empty,
+    (update / evictionWarningOptions).withRank(KeyRanks.Invisible) := EvictionWarningOptions.empty,
 
     checkLicenseHeaders := License.checkLicenseHeaders(streams.value.log, sourceDirectory.value),
     formatLicenseHeaders := License.formatLicenseHeaders(streams.value.log, sourceDirectory.value),
 
-    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+    packageBin / packageOptions += Package.ManifestAttributes(
       "Build-Date"   -> java.time.Instant.now().toString,
       "Build-Number" -> sys.env.getOrElse("GITHUB_RUN_ID", "unknown"),
       "Commit"       -> sys.env.getOrElse("GITHUB_SHA",    "unknown"))


### PR DESCRIPTION
Replace in with [slash syntax].

[slash syntax]: https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash