### PR TITLE
aws2: allow client impl to be specified

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -182,6 +182,7 @@ lazy val `iep-module-aws2` = project
     Dependencies.aws2Core,
     Dependencies.aws2EC2 % "test",
     Dependencies.aws2STS,
+    Dependencies.aws2UrlClient % "test",
     Dependencies.guiceCore,
     Dependencies.slf4jApi,
     Dependencies.typesafeConfig

--- a/iep-module-aws2/src/main/resources/reference.conf
+++ b/iep-module-aws2/src/main/resources/reference.conf
@@ -12,6 +12,18 @@ netflix.iep.aws {
     }
 
     client {
+      // Synchronous HTTP implementation class to use. If not explicitly set
+      // the service loader will be used to find an implementation on the classpath.
+      // If multiple implementation are present, then the first will be chosen
+      // and could be unpredictable.
+      //sync-http-impl = "software.amazon.awssdk.http.apache.ApacheSdkHttpService"
+
+      // Async HTTP implementation to use. If not explicitly set
+      // the service loader will be used to find an implementation on the classpath.
+      // If multiple implementation are present, then the first will be chosen
+      // and could be unpredictable.
+      //async-http-impl = "software.amazon.awssdk.http.nio.netty.NettySdkAsyncHttpService"
+
       // Timeout for the overall request, total time including all retries
       //api-call-timeout = 300s
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,6 +45,7 @@ object Dependencies {
   val aws2EC2            = "software.amazon.awssdk" % "ec2" % aws2
   val aws2SES            = "software.amazon.awssdk" % "ses" % aws2
   val aws2STS            = "software.amazon.awssdk" % "sts" % aws2
+  val aws2UrlClient      = "software.amazon.awssdk" % "url-connection-client" % aws2
   val caffeine           = "com.github.ben-manes.caffeine" % "caffeine" % "2.9.0"
   val equalsVerifier     = "nl.jqno.equalsverifier" % "equalsverifier" % "3.6"
   val eurekaClient       = "com.netflix.eureka" % "eureka-client" % eureka


### PR DESCRIPTION
Add config settings to specify which client implementation
will get used. Otherwise the SDK will fail when using the
factory and multiple implementations are present.