### PR TITLE
use guice 5 for newer JDKs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,9 +61,7 @@ lazy val `iep-eureka-testconfig` = project
 lazy val `iep-guice` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-service`)
-  .settings(libraryDependencies ++= Seq(
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.slf4jApi,
     Dependencies.jsr250 % "test"
   ))
@@ -93,21 +91,17 @@ lazy val `iep-leader-dynamodb` = project
 lazy val `iep-module-admin` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-admin`)
-  .settings(libraryDependencies ++= Seq(
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.slf4jApi
   ))
 
 lazy val `iep-module-archaius1` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.archaiusBridge,
     Dependencies.archaiusCore,
     Dependencies.archaiusGuice,
     Dependencies.archaiusLegacy,
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
     Dependencies.slf4jApi
   ))
 
@@ -126,9 +120,7 @@ lazy val `iep-module-archaius2` = project
 lazy val `iep-module-atlas` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-nflxenv`, `iep-service`)
-  .settings(libraryDependencies ++= Seq(
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.slf4jApi,
     Dependencies.spectatorApi,
     Dependencies.spectatorAtlas,
@@ -140,9 +132,7 @@ lazy val `iep-module-atlas` = project
 lazy val `iep-module-atlasaggr` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-nflxenv`, `iep-service`)
-  .settings(libraryDependencies ++= Seq(
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.slf4jApi,
     Dependencies.spectatorApi,
     Dependencies.spectatorStateless,
@@ -200,9 +190,7 @@ lazy val `iep-module-awsmetrics` = project
 lazy val `iep-module-dynconfig` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-nflxenv`, `iep-module-admin`)
-  .settings(libraryDependencies ++= Seq(
-      Dependencies.guiceCore,
-      Dependencies.guiceMulti,
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
       Dependencies.slf4jApi,
       Dependencies.spectatorApi,
       Dependencies.spectatorIpc
@@ -211,10 +199,8 @@ lazy val `iep-module-dynconfig` = project
 lazy val `iep-module-eureka` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-service`, `iep-module-admin`, `iep-eureka-testconfig` % "test")
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.eurekaClient,
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
     Dependencies.slf4jApi
   ))
 
@@ -228,9 +214,7 @@ lazy val `iep-module-jmxport` = project
 lazy val `iep-module-leader` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-leader-api`, `iep-service`)
-  .settings(libraryDependencies ++= Seq(
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.slf4jApi,
     Dependencies.spectatorApi,
     Dependencies.typesafeConfig,
@@ -249,10 +233,8 @@ lazy val `iep-module-rxnetty` = project
 lazy val `iep-module-userservice` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-module-admin`, `iep-service`)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.caffeine,
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
     Dependencies.jacksonMapper,
     Dependencies.slf4jApi,
     Dependencies.spectatorApi,
@@ -270,13 +252,11 @@ lazy val `iep-nflxenv` = project
 lazy val `iep-platformservice` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-nflxenv`, `iep-module-admin`)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.archaiusCore,
     Dependencies.archaiusGuice,
     Dependencies.archaiusPersist,
     Dependencies.archaiusTypesafe,
-    Dependencies.guiceCore,
-    Dependencies.guiceMulti,
     Dependencies.slf4jApi,
     Dependencies.spectatorApi,
     Dependencies.spectatorIpc

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,5 @@
 import sbt._
+import sbt.librarymanagement.DependencyBuilders.OrganizationArtifactName
 
 object Dependencies {
   object Versions {
@@ -8,7 +9,7 @@ object Dependencies {
     val aws2       = "2.16.45"
     val eureka     = "1.10.13"
     val graal      = "21.1.0"
-    val guice      = "4.1.0"
+    val guice      = "5.0.1"
     val jackson    = "2.12.3"
     val rxnetty    = "0.4.20"
     val rxscala    = "0.26.5"
@@ -51,8 +52,8 @@ object Dependencies {
   val eurekaClient       = "com.netflix.eureka" % "eureka-client" % eureka
   val graalJs            = "org.graalvm.js" % "js" % graal
   val graalJsEngine      = "org.graalvm.js" % "js-scriptengine" % graal
-  val guiceCore          = "com.google.inject" % "guice" % guice
-  val guiceMulti         = "com.google.inject.extensions" % "guice-multibindings" % guice
+  val guiceCoreBase      = "com.google.inject" % "guice"
+  val guiceMultiBase     = "com.google.inject.extensions" % "guice-multibindings"
   val inject             = "javax.inject" % "javax.inject" % "1"
   val jacksonCore        = "com.fasterxml.jackson.core" % "jackson-core" % jackson
   val jacksonMapper      = "com.fasterxml.jackson.core" % "jackson-databind" % jackson
@@ -74,4 +75,21 @@ object Dependencies {
   val spectatorJvm       = "com.netflix.spectator" % "spectator-ext-jvm" % spectator
   val spectatorStateless = "com.netflix.spectator" % "spectator-reg-stateless" % spectator
   val typesafeConfig     = "com.typesafe" % "config" % "1.4.1"
+
+  def isBeforeJava16: Boolean = {
+    System.getProperty("java.specification.version").toDouble < 16
+  }
+
+  private def guiceDep(base: OrganizationArtifactName): ModuleID = {
+    base % (if (isBeforeJava16) "4.1.0" else guice)
+  }
+
+  def guiceCore: ModuleID = guiceDep(guiceCoreBase)
+
+  def guiceCoreAndMulti: Seq[ModuleID] = {
+    if (isBeforeJava16)
+      Seq(guiceDep(guiceCoreBase), guiceDep(guiceMultiBase))
+    else
+      Seq(guiceDep(guiceCoreBase))
+  }
 }


### PR DESCRIPTION
Jdk16 strongly encapsulates the internals by default
causing problems for older versions of Guice. When
running on a newer JDK, have the build use Guice 5.
For the published library still need to use 4.1.0
to avoid creating problems internally for other
users stuck on old versions.