### PR TITLE
allow overriding the default sdk http client settings and ability to configure retries

### DIFF
--- a/iep-module-aws2/src/main/java/com/netflix/iep/aws2/AwsClientFactory.java
+++ b/iep-module-aws2/src/main/java/com/netflix/iep/aws2/AwsClientFactory.java
@@ -25,19 +25,26 @@ import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.SdkHttpService;
 import software.amazon.awssdk.http.async.SdkAsyncHttpService;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -88,6 +95,18 @@ public class AwsClientFactory implements AutoCloseable {
     }
   }
 
+  private void setRetriesIfPresent(Config cfg, ClientOverrideConfiguration.Builder builder) {
+    if (cfg.hasPath("retries")) {
+      RetryPolicy retryPolicy = RetryPolicy.builder()
+              .backoffStrategy(BackoffStrategy.defaultStrategy())
+              .throttlingBackoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
+              .numRetries(cfg.getInt("retries"))
+              .retryCondition(RetryCondition.defaultRetryCondition())
+              .build();
+      builder.retryPolicy(retryPolicy);
+    }
+  }
+
   ClientOverrideConfiguration createClientConfig(String name) {
     final Config cfg = getConfig(name, "client");
     ClientOverrideConfiguration.Builder builder = ClientOverrideConfiguration.builder();
@@ -97,6 +116,8 @@ public class AwsClientFactory implements AutoCloseable {
 
     setIfPresent(cfg, "user-agent-prefix", SdkAdvancedClientOption.USER_AGENT_PREFIX, builder);
     setIfPresent(cfg, "user-agent-suffix", SdkAdvancedClientOption.USER_AGENT_SUFFIX, builder);
+
+    setRetriesIfPresent(cfg, builder);
 
     if (cfg.hasPath("headers")) {
       for (String header : cfg.getStringList("headers")) {
@@ -167,6 +188,39 @@ public class AwsClientFactory implements AutoCloseable {
       }
       return dflt;
     }
+  }
+
+  AttributeMap getSdkHttpConfigurationOptions(String name) {
+    Map<AttributeMap.Key<?>, Object> configuration = new HashMap<>();
+    Config clientConfig = getConfig(name, "client");
+
+    if(clientConfig.hasPath("http-configuration")) {
+      Config httpConfig =  clientConfig.getConfig("http-configuration");
+      if (httpConfig.hasPath("read-timeout"))
+        configuration.put(SdkHttpConfigurationOption.READ_TIMEOUT, httpConfig.getDuration("read-timeout"));
+      if (httpConfig.hasPath("write-timeout"))
+        configuration.put(SdkHttpConfigurationOption.WRITE_TIMEOUT, httpConfig.getDuration("write-timeout"));
+      if (httpConfig.hasPath("connection-timeout"))
+        configuration.put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, httpConfig.getDuration("connection-timeout"));
+      if (httpConfig.hasPath("connection-acquire-timeout"))
+        configuration.put(SdkHttpConfigurationOption.CONNECTION_ACQUIRE_TIMEOUT, httpConfig.getDuration("connection-acquire-timeout"));
+      if (httpConfig.hasPath("connection-max-idle-timeout"))
+        configuration.put(SdkHttpConfigurationOption.CONNECTION_MAX_IDLE_TIMEOUT, httpConfig.getDuration("connection-max-idle-timeout"));
+      if (httpConfig.hasPath("connection-time-to-live"))
+        configuration.put(SdkHttpConfigurationOption.CONNECTION_TIME_TO_LIVE, httpConfig.getDuration("connection-time-to-live"));
+      if (httpConfig.hasPath("max-connections"))
+        configuration.put(SdkHttpConfigurationOption.MAX_CONNECTIONS, httpConfig.getInt("max-connections"));
+      if (httpConfig.hasPath("max-pending-connection-acquires"))
+        configuration.put(SdkHttpConfigurationOption.MAX_PENDING_CONNECTION_ACQUIRES, httpConfig.getInt("max-pending-connection-acquires"));
+      if (httpConfig.hasPath("reap-idle-connections"))
+        configuration.put(SdkHttpConfigurationOption.REAP_IDLE_CONNECTIONS, httpConfig.getBoolean("reap-idle-connections"));
+      if (httpConfig.hasPath("tcp-keepalive"))
+        configuration.put(SdkHttpConfigurationOption.TCP_KEEPALIVE, httpConfig.getBoolean("tcp-keepalive"));
+      if (httpConfig.hasPath("trust-all-certificates"))
+        configuration.put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, httpConfig.getBoolean("trust-all-certificates"));
+    }
+
+    return AttributeMap.builder().putAll(configuration).build();
   }
 
   private Region chooseRegion(String name, Class<?> cls) {
@@ -296,19 +350,20 @@ public class AwsClientFactory implements AutoCloseable {
   public <T> T newInstance(String name, Class<T> cls, String accountId) {
     try {
       SdkHttpService service = createSyncHttpService(name);
+      SdkAsyncHttpService asyncService = createAsyncHttpService(name);
       Method builderMethod = cls.getMethod("builder");
       AwsClientBuilder<?, ?> builder = ((AwsClientBuilder<?, ?>) builderMethod.invoke(null))
           .credentialsProvider(createCredentialsProvider(name, accountId, service))
           .region(chooseRegion(name, cls))
           .overrideConfiguration(createClientConfig(name));
+      AttributeMap attributeMap = getSdkHttpConfigurationOptions(name);
 
       if (builder instanceof AwsSyncClientBuilder<?, ?>) {
         ((AwsSyncClientBuilder<?, ?>) builder)
-            .httpClientBuilder(service.createHttpClientBuilder());
+                .httpClient(service.createHttpClientBuilder().buildWithDefaults(attributeMap));
       } else if (builder instanceof AwsAsyncClientBuilder<?, ?>) {
-        SdkAsyncHttpService asyncService = createAsyncHttpService(name);
         ((AwsAsyncClientBuilder<?, ?>) builder)
-            .httpClientBuilder(asyncService.createAsyncHttpClientFactory());
+                .httpClient(asyncService.createAsyncHttpClientFactory().buildWithDefaults(attributeMap));
       }
 
       return (T) builder.build();

--- a/iep-module-aws2/src/test/java/com/netflix/iep/aws2/AwsClientFactoryTest.java
+++ b/iep-module-aws2/src/test/java/com/netflix/iep/aws2/AwsClientFactoryTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.SdkHttpService;
 import software.amazon.awssdk.http.apache.ApacheSdkHttpService;
 import software.amazon.awssdk.services.ec2.Ec2AsyncClient;
@@ -32,6 +33,8 @@ import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeAddressesRequest;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.utils.AttributeMap;
+
 
 import java.lang.reflect.Field;
 import java.time.Duration;
@@ -252,5 +255,17 @@ public class AwsClientFactoryTest {
     ClientOverrideConfiguration settings = factory.createClientConfig("timeouts");
     Assert.assertEquals(Duration.ofMillis(42000), settings.apiCallAttemptTimeout().get());
     Assert.assertEquals(Duration.ofMillis(13000), settings.apiCallTimeout().get());
+    Assert.assertEquals(Integer.valueOf(5), settings.retryPolicy().get().numRetries());
+  }
+
+  @Test
+  public void settingsSdkHttpClient() {
+    AwsClientFactory factory = new AwsClientFactory(config);
+    AttributeMap settings = factory.getSdkHttpConfigurationOptions("sdk-http-client");
+    Assert.assertEquals(Duration.ofMillis(60000), settings.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT));
+    Assert.assertEquals(Duration.ofMillis(120000), settings.get(SdkHttpConfigurationOption.CONNECTION_MAX_IDLE_TIMEOUT));
+    Assert.assertEquals(500, settings.get(SdkHttpConfigurationOption.MAX_CONNECTIONS).intValue());
+    Assert.assertEquals(true, settings.get(SdkHttpConfigurationOption.REAP_IDLE_CONNECTIONS));
+
   }
 }

--- a/iep-module-aws2/src/test/resources/aws-client-factory.conf
+++ b/iep-module-aws2/src/test/resources/aws-client-factory.conf
@@ -39,6 +39,19 @@ netflix.iep.aws {
     client {
       api-call-attempt-timeout = 42s
       api-call-timeout = 13s
+      retries = 5
+    }
+  }
+
+  // Override the default sdk http config
+  sdk-http-client {
+    client {
+      http-configuration {
+        connection-timeout = "60s"
+        connection-max-idle-timeout = "120s"
+        max-connections = 500
+        reap-idle-connections = true
+      }
     }
   }
 

--- a/iep-module-aws2/src/test/resources/aws-client-factory.conf
+++ b/iep-module-aws2/src/test/resources/aws-client-factory.conf
@@ -39,7 +39,9 @@ netflix.iep.aws {
     client {
       api-call-attempt-timeout = 42s
       api-call-timeout = 13s
-      retries = 5
+      retry-policy {
+        num-retries = 5
+      }
     }
   }
 


### PR DESCRIPTION
allow overriding the default sdk http client settings and ability to configure retries.

Provides ability to override the [default sdk http configuration](https://github.com/aws/aws-sdk-java-v2/blob/master/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java#L137) and ability to configure [retries](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java)