### PR TITLE
try to show status for nimble groups

### DIFF
--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/GroupService.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/GroupService.java
@@ -79,9 +79,15 @@ public class GroupService extends AbstractService {
    * have been cached.
    */
   private boolean refreshOnce(String loaderName, Loader loader) {
+    AtomicLong lastUpdateTime = lastUpdateTimes.get(loaderName);
+    if (lastUpdateTime == null) {
+      // This can happen on shutdown if a refresh is scheduled after the map has
+      // been cleared.
+      return false;
+    }
     try {
       cachedData.put(loaderName, loader.call());
-      lastUpdateTimes.get(loaderName).set(registry.clock().wallTime());
+      lastUpdateTime.set(registry.clock().wallTime());
       merged = null;
       return true;
     } catch (Exception e) {

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
@@ -15,25 +15,20 @@
  */
 package com.netflix.iep.servergroups;
 
-import com.netflix.spectator.ipc.http.HttpClient;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
 @RunWith(JUnit4.class)
 public class EddaLoaderTest {
-  private final URI uri = URI.create("http://localhost:7101/api/v2/netflix/serverGroups");
 
   private List<ServerGroup> get(String resource) throws Exception {
-    HttpClient client = TestHttpClient.resource(200, resource);
-    EddaLoader loader = new EddaLoader(client, uri);
-    List<ServerGroup> groups = loader.call();
+    List<ServerGroup> groups = LoaderUtils.createEddaLoader(resource).call();
     groups.sort(Comparator.comparing(ServerGroup::getId));
     return groups;
   }

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EurekaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EurekaLoaderTest.java
@@ -30,17 +30,13 @@ import java.util.function.Predicate;
 
 @RunWith(JUnit4.class)
 public class EurekaLoaderTest {
-  private final URI uri = URI.create("http://localhost:7101/v2/apps");
 
   private List<ServerGroup> get(String resource) throws Exception {
     return get(resource, null);
   }
 
   private List<ServerGroup> get(String resource, String account) throws Exception {
-    HttpClient client = TestHttpClient.resource(200, resource);
-    Predicate<String> p = (account == null) ? v -> true : account::equals;
-    EurekaLoader loader = new EurekaLoader(client, uri, p);
-    List<ServerGroup> groups = loader.call();
+    List<ServerGroup> groups = LoaderUtils.createEurekaLoader(resource, account).call();
     groups.sort(Comparator.comparing(ServerGroup::getId));
     return groups;
   }
@@ -144,7 +140,7 @@ public class EurekaLoaderTest {
   @Test(expected = IOException.class)
   public void failedRequest() throws Exception {
     HttpClient client = TestHttpClient.empty(400);
-    EurekaLoader loader = new EurekaLoader(client, uri, v -> true);
+    EurekaLoader loader = new EurekaLoader(client, LoaderUtils.EUREKA_URI, v -> true);
     loader.call();
   }
 }

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/LoaderUtils.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/LoaderUtils.java
@@ -1,0 +1,29 @@
+package com.netflix.iep.servergroups;
+
+import com.netflix.spectator.ipc.http.HttpClient;
+
+import java.net.URI;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+
+final class LoaderUtils {
+
+  private LoaderUtils() {
+  }
+
+  static final URI EDDA_URI = URI.create("http://localhost:7101/api/v2/netflix/serverGroups");
+
+  static EddaLoader createEddaLoader(String resource) throws Exception {
+    HttpClient client = TestHttpClient.resource(200, resource);
+    return new EddaLoader(client, EDDA_URI);
+  }
+
+  static final URI EUREKA_URI = URI.create("http://localhost:7101/v2/apps");
+
+  static EurekaLoader createEurekaLoader(String resource, String account) throws Exception {
+    HttpClient client = TestHttpClient.resource(200, resource);
+    Predicate<String> p = (account == null) ? v -> true : account::equals;
+    return new EurekaLoader(client, EUREKA_URI, p);
+  }
+}

--- a/iep-servergroups/src/test/resources/edda-nimble.json
+++ b/iep-servergroups/src/test/resources/edda-nimble.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ec2.app-main-dev-v001",
+    "platform": "ec2",
+    "app": "app",
+    "cluster": "app-main-dev",
+    "group": "app-main-dev-v001",
+    "stack": "main",
+    "detail": "dev",
+    "minSize": 1,
+    "maxSize": 3,
+    "desiredSize": 2,
+    "instances": [
+      {
+        "launchTime": 1544328558000,
+        "node": "i-0001",
+        "privateIpAddress": "10.20.30.01",
+        "vpcId": "vpc-54321",
+        "subnetId": "subnet-54321",
+        "ami": "ami-0987654321",
+        "vmtype": "m5.large",
+        "zone": "us-east-1d"
+      }
+    ]
+  },
+  {
+    "id": "ec2.nimble_app-main-dev-v001",
+    "platform": "ec2",
+    "app": "nimble_app",
+    "cluster": "nimble_app-main-dev",
+    "group": "nimble_app-main-dev-v001",
+    "stack": "main",
+    "detail": "dev",
+    "minSize": 1,
+    "maxSize": 3,
+    "desiredSize": 2,
+    "instances": [
+      {
+        "launchTime": 1544328558000,
+        "node": "i-0002",
+        "privateIpAddress": "10.20.30.02",
+        "vpcId": "vpc-54321",
+        "subnetId": "subnet-54321",
+        "ami": "ami-0987654321",
+        "vmtype": "m5.large",
+        "zone": "us-east-1d"
+      }
+    ]
+  }
+]

--- a/iep-servergroups/src/test/resources/eureka-nimble.json
+++ b/iep-servergroups/src/test/resources/eureka-nimble.json
@@ -1,0 +1,121 @@
+{
+  "applications": {
+    "application": [
+      {
+        "name": "APP",
+        "instance": [
+          {
+            "instanceId": "i-0001",
+            "app": "APP",
+            "appGroupName": "UNKNOWN",
+            "ipAddr": "10.20.30.01",
+            "sid": "na",
+            "homePageUrl": "http://10.20.30.01:7101/",
+            "statusPageUrl": "http://10.20.30.01:7101/Status",
+            "healthCheckUrl": "http://10.20.30.01:7101/healthcheck",
+            "vipAddress": "app-main-dev:7001",
+            "countryId": 1,
+            "dataCenterInfo": {
+              "@class": "com.netflix.appinfo.AmazonInfo",
+              "name": "Amazon",
+              "metadata": {
+                "mac": "0a:0b:0c:0d:0e:0f",
+                "local-hostname": "ip-10-20-30-01.ec2.internal",
+                "instance-id": "i-0001",
+                "availability-zone": "us-east-1d",
+                "instance-type": "m5.large",
+                "ami-id": "ami-0987654321",
+                "accountId": "12345",
+                "public-hostname": "10.20.30.01",
+                "vpc-id": "vpc-54321",
+                "local-ipv4": "10.20.30.01"
+              }
+            },
+            "hostName": "10.20.30.01",
+            "status": "UP",
+            "overriddenStatus": "UNKNOWN",
+            "leaseInfo": {
+              "renewalIntervalInSecs": 30,
+              "durationInSecs": 90,
+              "registrationTimestamp": 1551379716423,
+              "lastRenewalTimestamp": 1551934330011,
+              "evictionTimestamp": 0,
+              "serviceUpTimestamp": 1551379716423
+            },
+            "isCoordinatingDiscoveryServer": false,
+            "lastUpdatedTimestamp": 1551379716423,
+            "lastDirtyTimestamp": 1551379715718,
+            "actionType": "ADDED",
+            "asgName": "app-main-dev-v001",
+            "port": {
+              "$": 7101,
+              "@enabled": "true"
+            },
+            "securePort": {
+              "$": 7102,
+              "@enabled": "false"
+            },
+            "metadata": {
+              "@class": "java.util.Collections$EmptyMap"
+            }
+          },
+          {
+            "instanceId": "i-0002",
+            "app": "APP",
+            "appGroupName": "UNKNOWN",
+            "ipAddr": "10.20.30.02",
+            "sid": "na",
+            "homePageUrl": "http://10.20.30.02:7101/",
+            "statusPageUrl": "http://10.20.30.02:7101/Status",
+            "healthCheckUrl": "http://10.20.30.02:7101/healthcheck",
+            "vipAddress": "app-main-dev:7002",
+            "countryId": 1,
+            "dataCenterInfo": {
+              "@class": "com.netflix.appinfo.AmazonInfo",
+              "name": "Amazon",
+              "metadata": {
+                "mac": "0a:0b:0c:0d:0e:0f",
+                "local-hostname": "ip-10-20-30-02.ec2.internal",
+                "instance-id": "i-0002",
+                "availability-zone": "us-east-1d",
+                "instance-type": "m5.large",
+                "ami-id": "ami-0987654321",
+                "accountId": "12345",
+                "public-hostname": "10.20.30.02",
+                "vpc-id": "vpc-54321",
+                "local-ipv4": "10.20.30.02"
+              }
+            },
+            "hostName": "10.20.30.02",
+            "status": "STARTING",
+            "overriddenStatus": "UNKNOWN",
+            "leaseInfo": {
+              "renewalIntervalInSecs": 30,
+              "durationInSecs": 90,
+              "registrationTimestamp": 1551379716423,
+              "lastRenewalTimestamp": 1551934330011,
+              "evictionTimestamp": 0,
+              "serviceUpTimestamp": 1551379716423
+            },
+            "isCoordinatingDiscoveryServer": false,
+            "lastUpdatedTimestamp": 1551379716423,
+            "lastDirtyTimestamp": 1551379715718,
+            "actionType": "ADDED",
+            "asgName": "app-main-dev-v001",
+            "port": {
+              "$": 7101,
+              "@enabled": "true"
+            },
+            "securePort": {
+              "$": 7102,
+              "@enabled": "false"
+            },
+            "metadata": {
+              "@class": "java.util.Collections$EmptyMap"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Nimble groups report to Eureka as if they are already
part of the transplant server group. Before they were
mostly ignored and would always have a status of not
registered. This change adds some hacks to try and
find the actual status for the nimble registration and
use that for the merged group. This only works when
there is a source such as Edda that has the correct
information earlier on.