### PR TITLE
add mantis tags to default atlas tag keys

### DIFF
--- a/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
@@ -101,6 +101,12 @@ public class NetflixEnvironment {
   private static final Set DEFAULT_ATLAS_TAG_KEYS;
   static {
     Set<String> tagKeys = new HashSet<>();
+    tagKeys.add("mantisJobId");
+    tagKeys.add("mantisJobName");
+    tagKeys.add("mantisUser");
+    tagKeys.add("mantisWorkerIndex");
+    tagKeys.add("mantisWorkerNumber");
+    tagKeys.add("mantisWorkerStageNumber");
     tagKeys.add("nf.account");
     tagKeys.add("nf.app");
     tagKeys.add("nf.asg");
@@ -113,6 +119,7 @@ public class NetflixEnvironment {
     tagKeys.add("nf.vmtype");
     tagKeys.add("nf.zone");
     tagKeys.add("process");
+
     DEFAULT_ATLAS_TAG_KEYS = Collections.unmodifiableSet(tagKeys);
   }
 

--- a/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
+++ b/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
@@ -117,7 +117,6 @@ public class NetflixEnvironmentTest {
     expected.remove("sourceRepo");
     expected.remove("branch");
     expected.remove("commit");
-    expected.keySet().removeIf(k -> k.startsWith("mantis"));
     return expected;
   }
 


### PR DESCRIPTION
The Mantis tags have long been a part of Atlas metrics common tagging, and
they only appear in the Mantis application clusters, so it is safe to add
them to the default set.

Making this change here, rather than creating a separate set of keys to
cover this use case, means that there will remain one standard source for
Atlas metrics common tags.