### PR TITLE
eureka: use ip rather than host by default

### DIFF
--- a/iep-module-eureka/src/main/java/com/netflix/iep/eureka/CustomEurekaInstanceConfig.java
+++ b/iep-module-eureka/src/main/java/com/netflix/iep/eureka/CustomEurekaInstanceConfig.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.iep.eureka;
 
+import com.netflix.appinfo.AmazonInfo;
 import com.netflix.appinfo.PropertiesInstanceConfig;
 
 import javax.inject.Inject;
@@ -26,5 +27,12 @@ class CustomEurekaInstanceConfig extends PropertiesInstanceConfig {
   @Inject
   CustomEurekaInstanceConfig() {
     super("netflix.appinfo.", AmazonInfoUtils.createFromEnvironment());
+  }
+
+  @Override
+  public String getHostName(boolean refresh) {
+    AmazonInfo info = (AmazonInfo) getDataCenterInfo();
+    String ip = info.get(AmazonInfo.MetaDataKey.localHostname);
+    return ip == null ? super.getHostName(refresh) : ip;
   }
 }


### PR DESCRIPTION
Prefer the IP address from the environment rather than
the hostname extracted from the system. On many instances
that hostmame is not resolvable off the instance.