### PR TITLE
update validation for Eureka instance type

### DIFF
--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EurekaLoader.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EurekaLoader.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -40,6 +41,11 @@ import java.util.zip.GZIPInputStream;
  * can be used as a backup if data coming from other sources is stale.
  */
 public class EurekaLoader implements Loader {
+
+  // Some environments like Titus can result in arbitrary values for the
+  // instance type in the metadata. This pattern is used to check for reasonable
+  // values.
+  private static final Pattern VM_TYPE_PATTERN = Pattern.compile("^[a-zA-Z0-9]+\\.[a-zA-Z0-9]+$");
 
   private final HttpClient client;
   private final URI uri;
@@ -94,7 +100,7 @@ public class EurekaLoader implements Loader {
           break;
         case "instance-type":
           String vmtype = JsonUtils.stringValue(p);
-          if (!"Titus".equals(vmtype)) {
+          if (vmtype != null && VM_TYPE_PATTERN.matcher(vmtype).matches()) {
             info.builder.vmtype(vmtype);
           }
           break;

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EurekaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EurekaLoaderTest.java
@@ -131,6 +131,24 @@ public class EurekaLoaderTest {
   }
 
   @Test
+  public void titusGroupVmtype() throws Exception {
+    List<ServerGroup> expected = new ArrayList<>();
+    expected.add(ServerGroup.builder()
+        .platform("titus")
+        .group("app-main-v001")
+        .addInstance(Instance.builder()
+            .node("8d78c384-aa57-48cc-ad4d-a1a887f46221")
+            .privateIpAddress("10.20.30.40")
+            .vpcId("vpc-54321")
+            .zone("us-east-1d")
+            .status(Instance.Status.UP)
+            .build())
+        .build());
+    List<ServerGroup> actual = get("eureka-titus-2.json", "12345");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void invalidInstance() throws Exception {
     List<ServerGroup> expected = new ArrayList<>();
     List<ServerGroup> actual = get("eureka-invalid.json");

--- a/iep-servergroups/src/test/resources/eureka-titus-2.json
+++ b/iep-servergroups/src/test/resources/eureka-titus-2.json
@@ -1,0 +1,65 @@
+{
+  "applications": {
+    "application": [
+      {
+        "name": "APP",
+        "instance": [
+          {
+            "instanceId": "8d78c384-aa57-48cc-ad4d-a1a887f46221",
+            "app": "APP",
+            "appGroupName": "UNKNOWN",
+            "ipAddr": "10.20.30.40",
+            "sid": "na",
+            "homePageUrl": "http://10.20.30.40:7101/",
+            "statusPageUrl": "http://10.20.30.40:7101/Status",
+            "healthCheckUrl": "http://10.20.30.40:7101/healthcheck",
+            "vipAddress": "app-main:7001",
+            "countryId": 1,
+            "dataCenterInfo": {
+              "@class": "com.netflix.appinfo.AmazonInfo",
+              "name": "Amazon",
+              "metadata": {
+                "mac": "0a:0b:0c:0d:0e:0f",
+                "local-hostname": "ip-10-20-30-40.ec2.internal",
+                "instance-id": "8d78c384-aa57-48cc-ad4d-a1a887f46221",
+                "availability-zone": "us-east-1d",
+                "instance-type": "CPU=10;GPU=0;MEM=64000;NET=128;DISK=10000",
+                "accountId": "12345",
+                "public-hostname": "10.20.30.40",
+                "vpc-id": "vpc-54321",
+                "local-ipv4": "10.20.30.40"
+              }
+            },
+            "hostName": "10.20.30.40",
+            "status": "UP",
+            "overriddenStatus": "UNKNOWN",
+            "leaseInfo": {
+              "renewalIntervalInSecs": 30,
+              "durationInSecs": 90,
+              "registrationTimestamp": 1551379716423,
+              "lastRenewalTimestamp": 1551934330011,
+              "evictionTimestamp": 0,
+              "serviceUpTimestamp": 1551379716423
+            },
+            "isCoordinatingDiscoveryServer": false,
+            "lastUpdatedTimestamp": 1551379716423,
+            "lastDirtyTimestamp": 1551379715718,
+            "actionType": "ADDED",
+            "asgName": "app-main-v001",
+            "port": {
+              "$": 7101,
+              "@enabled": "true"
+            },
+            "securePort": {
+              "$": 7102,
+              "@enabled": "false"
+            },
+            "metadata": {
+              "@class": "java.util.Collections$EmptyMap"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
In some cases with Titus we are seeing unexpected values
that explicitly enumerate various resources.