### PR TITLE
fix memory leak for compressed responses

### DIFF
--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class EddaLoaderTest {
 
   private List<ServerGroup> get(String resource) throws Exception {
-    List<ServerGroup> groups = LoaderUtils.createEddaLoader(resource).call();
+    List<ServerGroup> groups = LoaderUtils.createEddaLoader(resource, false).call();
     groups.sort(Comparator.comparing(ServerGroup::getId));
     return groups;
   }
@@ -58,6 +58,17 @@ public class EddaLoaderTest {
     List<ServerGroup> expected = new ArrayList<>();
     expected.add(defaultEc2Group());
     List<ServerGroup> actual = get("edda-ec2.json");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void ec2GroupGzip() throws Exception {
+    List<ServerGroup> expected = new ArrayList<>();
+    expected.add(defaultEc2Group());
+    List<ServerGroup> actual = LoaderUtils
+        .createEddaLoader("edda-ec2.json", true)
+        .call();
+    actual.sort(Comparator.comparing(ServerGroup::getId));
     Assert.assertEquals(expected, actual);
   }
 

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/GroupServiceTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/GroupServiceTest.java
@@ -114,7 +114,7 @@ public class GroupServiceTest {
   @Test
   public void nimbleMerge() throws Exception {
     Map<String, Loader> loaders = new LinkedHashMap<>();
-    loaders.put("edda", LoaderUtils.createEddaLoader("edda-nimble.json"));
+    loaders.put("edda", LoaderUtils.createEddaLoader("edda-nimble.json", false));
     loaders.put("eureka", LoaderUtils.createEurekaLoader("eureka-nimble.json", "12345"));
     GroupService service = new GroupService(new NoopRegistry(), Duration.ZERO, loaders);
     service.start();

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/LoaderUtils.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/LoaderUtils.java
@@ -18,8 +18,6 @@ package com.netflix.iep.servergroups;
 import com.netflix.spectator.ipc.http.HttpClient;
 
 import java.net.URI;
-import java.util.Comparator;
-import java.util.List;
 import java.util.function.Predicate;
 
 final class LoaderUtils {
@@ -29,15 +27,15 @@ final class LoaderUtils {
 
   static final URI EDDA_URI = URI.create("http://localhost:7101/api/v2/netflix/serverGroups");
 
-  static EddaLoader createEddaLoader(String resource) throws Exception {
-    HttpClient client = TestHttpClient.resource(200, resource);
+  static EddaLoader createEddaLoader(String resource, boolean gzip) throws Exception {
+    HttpClient client = TestHttpClient.resource(200, resource, gzip);
     return new EddaLoader(client, EDDA_URI);
   }
 
   static final URI EUREKA_URI = URI.create("http://localhost:7101/v2/apps");
 
   static EurekaLoader createEurekaLoader(String resource, String account) throws Exception {
-    HttpClient client = TestHttpClient.resource(200, resource);
+    HttpClient client = TestHttpClient.resource(200, resource, false);
     Predicate<String> p = (account == null) ? v -> true : account::equals;
     return new EurekaLoader(client, EUREKA_URI, p);
   }


### PR DESCRIPTION
The server groups loader could leak native memory if
the gzip stream wasn't closed. Since the json library
will automatically try to close if it hits the end
of stream, the leak would only occur if there was an
error parsing or the parsing stopped before fully
consuming the input.