### PR TITLE
remove invalid chars for Atlas tags

### DIFF
--- a/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
+++ b/iep-nflxenv/src/main/java/com/netflix/iep/NetflixEnvironment.java
@@ -125,8 +125,21 @@ public class NetflixEnvironment {
     tagKeys.add("nf.vmtype");
     tagKeys.add("nf.zone");
 
-
     DEFAULT_ATLAS_TAG_KEYS = Collections.unmodifiableSet(tagKeys);
+  }
+
+  /** Replace characters not allowed by Atlas with underscore. */
+  private static String fixTagString(String str) {
+    return str.replaceAll("[^-._A-Za-z0-9~^]", "_");
+  }
+
+  /** Fix tag strings for map to ensure they are valid for Atlas. */
+  private static Map<String, String> fixTagStrings(Map<String, String> tags) {
+    Map<String, String> result = new HashMap<>();
+    for (Map.Entry<String, String> entry : tags.entrySet()) {
+      result.put(fixTagString(entry.getKey()), fixTagString(entry.getValue()));
+    }
+    return result;
   }
 
   /**
@@ -220,7 +233,7 @@ public class NetflixEnvironment {
    *     Common tags based on the environment.
    */
   public static Map<String, String> commonTagsForAtlas(Function<String, String> getenv) {
-    return commonTagsForAtlas(getenv, defaultAtlasKeyPredicate(getenv));
+    return fixTagStrings(commonTagsForAtlas(getenv, defaultAtlasKeyPredicate(getenv)));
   }
 
   /**

--- a/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
+++ b/iep-nflxenv/src/test/java/com/netflix/iep/NetflixEnvironmentTest.java
@@ -75,7 +75,7 @@ public class NetflixEnvironmentTest {
     vars.put("MANTIS_WORKER_INDEX", "0");
     vars.put("MANTIS_WORKER_NUMBER", "4");
     vars.put("MANTIS_WORKER_STAGE_NUMBER", "5");
-    vars.put("MANTIS_USER", "bob");
+    vars.put("MANTIS_USER", "bob@example.com");
     return vars;
   }
 
@@ -107,7 +107,7 @@ public class NetflixEnvironmentTest {
     vars.put("mantisWorkerIndex", "0");
     vars.put("mantisWorkerNumber", "4");
     vars.put("mantisWorkerStageNumber", "5");
-    vars.put("mantisUser", "bob");
+    vars.put("mantisUser", "bob@example.com");
     return vars;
   }
 
@@ -119,6 +119,7 @@ public class NetflixEnvironmentTest {
     expected.remove("sourceRepo");
     expected.remove("branch");
     expected.remove("commit");
+    expected.put("mantisUser", "bob_example.com");
     return expected;
   }
 


### PR DESCRIPTION
Ensure that the tags returned for Atlas comply with the
validation rules.