### PR TITLE
move default bindings to configuration class

### DIFF
--- a/iep-spring/src/main/java/com/netflix/iep/spring/IepConfiguration.java
+++ b/iep-spring/src/main/java/com/netflix/iep/spring/IepConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.spring;
+
+import com.netflix.iep.service.ClassFactory;
+import com.netflix.iep.service.Service;
+import com.netflix.iep.service.ServiceManager;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Set;
+
+/**
+ * Base configuration needed for most IEP apps.
+ */
+@Configuration
+public class IepConfiguration {
+
+  @Bean
+  ClassFactory classFactory(ApplicationContext context) {
+    return new SpringClassFactory(context);
+  }
+
+  @Bean
+  ServiceManager serviceManager(Set<Service> services) {
+    return new ServiceManager(services);
+  }
+}

--- a/iep-spring/src/main/java/com/netflix/iep/spring/Main.java
+++ b/iep-spring/src/main/java/com/netflix/iep/spring/Main.java
@@ -60,15 +60,9 @@ public class Main implements AutoCloseable {
     );
 
     try {
-      // Binding for class factory
-      context.registerBean(SpringClassFactory.class);
-
       // Binding for command line arguments
+      context.register(IepConfiguration.class);
       context.registerBean(Args.class, () -> Args.from(args));
-
-      // Binding for service manager
-      context.registerBean(ServiceManager.class);
-
       context.refresh();
 
       // Start up

--- a/iep-spring/src/test/java/com/netflix/iep/spring/MainTest.java
+++ b/iep-spring/src/test/java/com/netflix/iep/spring/MainTest.java
@@ -23,7 +23,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.springframework.beans.factory.UnsatisfiedDependencyException;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 
@@ -59,7 +59,7 @@ public class MainTest {
     boolean startupFailed = false;
     try {
       Main.run(new String[]{}, context);
-    } catch (UnsatisfiedDependencyException e) {
+    } catch (BeanCreationException e) {
       startupFailed = true;
       Assert.assertEquals("missing required argument", e.getRootCause().getMessage());
     } finally {
@@ -73,7 +73,7 @@ public class MainTest {
     boolean startupFailed = false;
     try {
       Main.main(new String[]{});
-    } catch (UnsatisfiedDependencyException e) {
+    } catch (BeanCreationException e) {
       startupFailed = true;
       Assert.assertEquals("missing required argument", e.getRootCause().getMessage());
     } finally {
@@ -108,7 +108,7 @@ public class MainTest {
     boolean startupFailed = false;
     try {
       Main.run(new String[]{"foo"});
-    } catch (UnsatisfiedDependencyException e) {
+    } catch (BeanCreationException e) {
       startupFailed = true;
       Assert.assertEquals("unknown mode: foo", e.getRootCause().getMessage());
     } finally {


### PR DESCRIPTION
Makes it easier to reuse in other contexts where the Main
class may not be used.