### PR TITLE
all default configuration to be omitted

### DIFF
--- a/iep-spring/src/main/java/com/netflix/iep/spring/Main.java
+++ b/iep-spring/src/main/java/com/netflix/iep/spring/Main.java
@@ -61,7 +61,6 @@ public class Main implements AutoCloseable {
 
     try {
       // Binding for command line arguments
-      context.register(IepConfiguration.class);
       context.registerBean(Args.class, () -> Args.from(args));
       context.refresh();
 

--- a/iep-spring/src/test/java/com/netflix/iep/spring/MainTest.java
+++ b/iep-spring/src/test/java/com/netflix/iep/spring/MainTest.java
@@ -43,6 +43,7 @@ public class MainTest {
 
   private AnnotationConfigApplicationContext createContext() {
     AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.register(IepConfiguration.class);
     return context;
   }
 

--- a/iep-spring/src/test/java/com/netflix/iep/spring/config/TestConfiguration.java
+++ b/iep-spring/src/test/java/com/netflix/iep/spring/config/TestConfiguration.java
@@ -16,11 +16,14 @@
 package com.netflix.iep.spring.config;
 
 import com.netflix.iep.spring.Args;
+import com.netflix.iep.spring.IepConfiguration;
 import com.netflix.iep.spring.TestService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
+@Import(IepConfiguration.class)
 public class TestConfiguration {
 
   @Bean


### PR DESCRIPTION
When explicitly setting up the ApplicationContext the
default IepConfiguration must be explictly added if
desirable. Allows the user to omit it if desirable for
more control.