### PR TITLE
update leader status binding

### DIFF
--- a/iep-spring-leader/src/main/java/com/netflix/iep/leader/LeaderConfiguration.java
+++ b/iep-spring-leader/src/main/java/com/netflix/iep/leader/LeaderConfiguration.java
@@ -17,6 +17,7 @@ package com.netflix.iep.leader;
 
 import com.netflix.iep.leader.api.LeaderDatabase;
 import com.netflix.iep.leader.api.LeaderElector;
+import com.netflix.iep.leader.api.LeaderStatus;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
 import com.typesafe.config.Config;
@@ -30,7 +31,7 @@ import java.util.Optional;
 public class LeaderConfiguration {
 
   @Bean
-  LeaderElector leaderElector(
+  StandardLeaderElector leaderElector(
       LeaderDatabase db, Optional<Registry> registry, Optional<Config> config) {
     Registry r = registry.orElseGet(NoopRegistry::new);
     Config c = config.orElseGet(ConfigFactory::load);

--- a/iep-spring-leader/src/test/java/com/netflix/iep/leader/LeaderConfigurationTest.java
+++ b/iep-spring-leader/src/test/java/com/netflix/iep/leader/LeaderConfigurationTest.java
@@ -23,6 +23,8 @@ import com.netflix.iep.leader.api.ResourceId;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 public class LeaderConfigurationTest {
 
@@ -72,6 +74,18 @@ public class LeaderConfigurationTest {
   }
 
   @Test
+  public void leaderStatusInject() {
+    try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+      context.register(LeaderConfiguration.class, TestConfiguration.class);
+      context.registerBean(LeaderDatabase.class, this::createLeaderDatabase);
+      context.refresh();
+      context.start();
+      StatusWrapper wrapper = context.getBean(StatusWrapper.class);
+      Assert.assertNotNull(wrapper.status);
+    }
+  }
+
+  @Test
   public void leaderService() {
     try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
       context.register(LeaderConfiguration.class);
@@ -79,6 +93,24 @@ public class LeaderConfigurationTest {
       context.refresh();
       context.start();
       Assert.assertNotNull(context.getBean(LeaderService.class));
+    }
+  }
+
+  @Configuration
+  public static class TestConfiguration {
+
+    @Bean
+    StatusWrapper statusString(LeaderStatus status) {
+      return new StatusWrapper(status);
+    }
+  }
+
+  public static class StatusWrapper {
+
+    final LeaderStatus status;
+
+    StatusWrapper(LeaderStatus status) {
+      this.status = status;
     }
   }
 }


### PR DESCRIPTION
Use the concrete type in the return value since it
implements both LeaderElector and LeaderStatus. This
avoids errors about missing bindings in some cases.