### PR TITLE
fix dynamic config injection

### DIFF
--- a/iep-spring-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigConfiguration.java
+++ b/iep-spring-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigConfiguration.java
@@ -39,7 +39,10 @@ public class DynamicConfigConfiguration {
   }
 
   @Bean
-  DynamicConfigManager dynamicConfigManager() {
+  DynamicConfigManager dynamicConfigManager(DynamicConfigService service) {
+    // The service parameter is necessary to ensure that the dependency injector will
+    // create the service and update the remote layer before injecting the DynamicConfigManager
+    // into other objects.
     return ConfigManager.dynamicConfigManager();
   }
 

--- a/iep-spring/src/test/java/com/netflix/iep/spring/LifecycleTest.java
+++ b/iep-spring/src/test/java/com/netflix/iep/spring/LifecycleTest.java
@@ -121,6 +121,23 @@ public class LifecycleTest {
     Assert.assertEquals(State.STOPPED, obj.getState());
   }
 
+  @Test
+  public void postConstructCalledBeforeInjecting() throws Exception {
+    InjectedStateObject obj;
+
+    try (AnnotationConfigApplicationContext context = createContext()) {
+      context.registerBean(StateObject.class, StateObject::new, bd -> bd.setScope("singleton"));
+      context.registerBean(InjectedStateObject.class);
+      context.refresh();
+      context.start();
+
+      obj = context.getBean(InjectedStateObject.class);
+      Assert.assertEquals(State.STARTED, obj.getState());
+    }
+
+    Assert.assertEquals(State.STOPPED, obj.getState());
+  }
+
   private enum State {
     INIT, STARTED, STOPPED
   }
@@ -176,6 +193,23 @@ public class LifecycleTest {
 
     State getState() {
       return state;
+    }
+  }
+
+
+  @Singleton
+  private static class InjectedStateObject {
+
+    private StateObject obj;
+
+    @Inject
+    InjectedStateObject(StateObject obj) {
+      this.obj = obj;
+      Assert.assertEquals(State.STARTED, obj.getState());
+    }
+
+    State getState() {
+      return obj.getState();
     }
   }
 }


### PR DESCRIPTION
Update the dependencies to ensure that the dynamic config service will have been created and synced the remote config before the DynamicConfigManager bean will be created and available for injection. Otherwise the remote settings may not be available on startup.