### PR TITLE
disable Atlas bindings if SBN detected

### DIFF
--- a/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/AtlasConfiguration.java
+++ b/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/AtlasConfiguration.java
@@ -19,6 +19,7 @@ import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Registry;
 import com.typesafe.config.Config;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.Optional;
@@ -27,6 +28,7 @@ import java.util.Optional;
  * Setup registry for reporting spectator data to Atlas.
  */
 @Configuration
+@Conditional(NoSbnCondition.class)
 public class AtlasConfiguration {
 
   @Bean

--- a/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/NoSbnCondition.java
+++ b/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/NoSbnCondition.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.atlas;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * If the property for the internal SBN bindings is present, then disable the configuration.
+ * Helps mitigate issues with poor dependency hygiene.
+ */
+class NoSbnCondition implements Condition {
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    String v = context.getEnvironment().getProperty("management.metrics.export.atlas.enabled");
+    return v == null;
+  }
+}

--- a/iep-spring-atlas/src/test/java/com/netflix/iep/atlas/AtlasConfigurationTest.java
+++ b/iep-spring-atlas/src/test/java/com/netflix/iep/atlas/AtlasConfigurationTest.java
@@ -21,7 +21,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(JUnit4.class)
 public class AtlasConfigurationTest {
@@ -34,6 +39,21 @@ public class AtlasConfigurationTest {
       context.start();
       Registry registry = context.getBean(Registry.class);
       Assert.assertTrue(registry instanceof AtlasRegistry);
+    }
+  }
+
+  @Test(expected = NoSuchBeanDefinitionException.class)
+  public void registryIsNotBoundIfSbnIsPresent() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("management.metrics.export.atlas.enabled", "true");
+    try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+      context.getEnvironment()
+          .getPropertySources()
+          .addFirst(new MapPropertySource("test", props));
+      context.register(AtlasConfiguration.class);
+      context.refresh();
+      context.start();
+      context.getBean(Registry.class);
     }
   }
 }


### PR DESCRIPTION
If the SBN metrics properties are detected, then disable the configuration and assume SBN will be used for configuring the registry.