### PR TITLE
filter out empty property sources

### DIFF
--- a/iep-spring-admin/src/main/java/com/netflix/iep/admin/spring/SpringEnvEndpoint.java
+++ b/iep-spring-admin/src/main/java/com/netflix/iep/admin/spring/SpringEnvEndpoint.java
@@ -49,7 +49,11 @@ public class SpringEnvEndpoint implements HttpEndpoint {
 
   @Override public Object get(String path) {
     Map<String, Map<String, Object>> sources = new LinkedHashMap<>();
-    getPropertyMap().forEach((key, value) -> sources.put(key, filter(value, path)));
+    getPropertyMap().forEach((key, value) -> {
+      Map<String, Object> filtered = filter(value, path);
+      if (!filtered.isEmpty())
+        sources.put(key, filtered);
+    });
     return sources;
   }
 
@@ -57,7 +61,7 @@ public class SpringEnvEndpoint implements HttpEndpoint {
     Map<String, Object> filtered = new TreeMap<>();
     props.entrySet()
         .stream()
-        .filter(e -> e.getKey().toString().startsWith(prefix))
+        .filter(e -> e.getKey().startsWith(prefix))
         .forEach(e -> filtered.put(e.getKey(), e.getValue()));
     return filtered;
   }

--- a/iep-spring-admin/src/test/java/com/netflix/iep/admin/spring/SpringEnvEndpointTest.java
+++ b/iep-spring-admin/src/test/java/com/netflix/iep/admin/spring/SpringEnvEndpointTest.java
@@ -82,8 +82,6 @@ public class SpringEnvEndpointTest {
     Map<String, Map<String, Object>> expected = new LinkedHashMap<>();
     expected.put("test1", propsMap("foo.bar", "1"));
     expected.put("test2", propsMap("foo.bar", "2", "foo.baz", "abc"));
-    expected.put("systemProperties", propsMap());
-    expected.put("systemEnvironment", propsMap());
     Assert.assertEquals(expected, endpoint.get("foo"));
   }
 }


### PR DESCRIPTION
When accessing properties with a given prefix, filter out the sources that are empty. Helps reduce clutter when there are many property sources.