### PR TITLE
reduce usage of javax annotations

### DIFF
--- a/iep-admin/src/main/java/com/netflix/iep/admin/AdminServer.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/AdminServer.java
@@ -21,8 +21,6 @@ import com.sun.net.httpserver.HttpServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collections;
@@ -36,7 +34,6 @@ import java.util.stream.Collectors;
 /**
  * Simple side server used to provide debugging information for the main application.
  */
-@Singleton
 public class AdminServer implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AdminServer.class);
@@ -56,7 +53,6 @@ public class AdminServer implements AutoCloseable {
     this(config, toMap(mappings));
   }
 
-  @Inject
   public AdminServer(AdminConfig config, @AdminEndpoint Map<String, Object> endpoints)
       throws IOException {
     this.config = config;

--- a/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/BaseServerEndpoint.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/BaseServerEndpoint.java
@@ -22,7 +22,6 @@ import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Tag;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -37,7 +36,6 @@ public class BaseServerEndpoint implements HttpEndpoint {
   private final JarsEndpoint jars = new JarsEndpoint();
   private final Registry registry;
 
-  @Inject
   public BaseServerEndpoint(Registry registry) {
     this.registry = registry;
   }

--- a/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/JmxEndpoint.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/JmxEndpoint.java
@@ -20,7 +20,6 @@ import com.netflix.iep.admin.HttpEndpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import javax.management.Attribute;
 import javax.management.AttributeList;
 import javax.management.MBeanAttributeInfo;
@@ -52,7 +51,6 @@ public class JmxEndpoint implements HttpEndpoint {
   /**
    * Create a new instance using the local platform MBean server.
    */
-  @Inject
   public JmxEndpoint() {
     this(ManagementFactory.getPlatformMBeanServer());
   }

--- a/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/ServicesEndpoint.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/ServicesEndpoint.java
@@ -19,7 +19,6 @@ import com.netflix.iep.admin.HttpEndpoint;
 import com.netflix.iep.service.Service;
 import com.netflix.iep.service.ServiceManager;
 
-import javax.inject.Inject;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -31,7 +30,6 @@ public class ServicesEndpoint implements HttpEndpoint {
 
   private final ServiceManager manager;
 
-  @Inject
   public ServicesEndpoint(ServiceManager manager) {
     this.manager = manager;
   }

--- a/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/SpectatorEndpoint.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/SpectatorEndpoint.java
@@ -25,7 +25,6 @@ import com.netflix.spectator.api.Tag;
 import com.netflix.spectator.api.Timer;
 import com.netflix.spectator.impl.Preconditions;
 
-import javax.inject.Inject;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -48,7 +47,6 @@ public class SpectatorEndpoint implements HttpEndpoint {
 
   private final Registry registry;
 
-  @Inject
   public SpectatorEndpoint(Registry registry) {
     this.registry = registry;
   }

--- a/iep-leader-api/src/main/java/com/netflix/iep/leader/StandardLeaderElector.java
+++ b/iep-leader-api/src/main/java/com/netflix/iep/leader/StandardLeaderElector.java
@@ -26,8 +26,6 @@ import com.typesafe.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -52,7 +50,6 @@ import java.util.stream.Collectors;
  * <li>{@code reference.conf} - the full list of configuration options</li>
  * <li>{@code README.conf} - the metrics provided</li>
  */
-@Singleton
 public class StandardLeaderElector implements LeaderElector, LeaderStatus {
 
   private static final Logger logger = LoggerFactory.getLogger(StandardLeaderElector.class);
@@ -67,7 +64,6 @@ public class StandardLeaderElector implements LeaderElector, LeaderStatus {
   private final Id resourceLeaderGaugeId;
   private final Id resourceWithNoLeaderGaugeId;
 
-  @Inject
   public StandardLeaderElector(LeaderDatabase leaderDatabase, Config config, Registry registry) {
     this(
         LeaderId.create(config),

--- a/iep-service/src/main/java/com/netflix/iep/service/ServiceManager.java
+++ b/iep-service/src/main/java/com/netflix/iep/service/ServiceManager.java
@@ -15,8 +15,6 @@
  */
 package com.netflix.iep.service;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -29,12 +27,10 @@ import java.util.Set;
  * is managed via the DI framework, typically via PostConstruct and PreDestroy annotations. All
  * services should be injected into the set for this manager.
  */
-@Singleton
 public class ServiceManager {
 
   private final List<Service> services;
 
-  @Inject
   public ServiceManager(Set<Service> serviceSet) {
     services = new ArrayList<>();
     services.addAll(serviceSet);

--- a/iep-spring-admin/src/main/java/com/netflix/iep/admin/spring/SpringBeansEndpoint.java
+++ b/iep-spring-admin/src/main/java/com/netflix/iep/admin/spring/SpringBeansEndpoint.java
@@ -21,8 +21,6 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
@@ -31,12 +29,10 @@ import java.util.stream.Collectors;
 /**
  * Endpoint that provides a list of keys available via the Spring ApplicationContext.
  */
-@Singleton
 public class SpringBeansEndpoint implements HttpEndpoint {
 
   private final ApplicationContext context;
 
-  @Inject
   public SpringBeansEndpoint(ApplicationContext context) {
     this.context = context;
   }

--- a/iep-spring-admin/src/main/java/com/netflix/iep/admin/spring/SpringEnvEndpoint.java
+++ b/iep-spring-admin/src/main/java/com/netflix/iep/admin/spring/SpringEnvEndpoint.java
@@ -20,10 +20,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
-import org.springframework.core.env.Environment;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -31,12 +28,10 @@ import java.util.TreeMap;
 /**
  * Endpoint that provides an overview of properties in the Spring environment.
  */
-@Singleton
 public class SpringEnvEndpoint implements HttpEndpoint {
 
   private final ConfigurableEnvironment env;
 
-  @Inject
   public SpringEnvEndpoint(ApplicationContext context) {
     this.env = (context instanceof GenericApplicationContext)
         ? ((GenericApplicationContext) context).getEnvironment()

--- a/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
+++ b/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
@@ -30,7 +30,6 @@ import com.typesafe.config.ConfigFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,6 @@ import java.util.Map;
  * started when accessed, but never stopped. This means that the final metrics
  * during shutdown may not get reported correctly.
  */
-@Singleton
 class AtlasRegistryService extends AbstractService {
 
   private static Config defaultConfig() {

--- a/iep-spring-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigService.java
+++ b/iep-spring-dynconfig/src/main/java/com/netflix/iep/dynconfig/DynamicConfigService.java
@@ -27,7 +27,6 @@ import com.typesafe.config.ConfigFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,7 +51,6 @@ class DynamicConfigService extends AbstractService {
   private final boolean syncInit;
   private final ScheduledExecutorService executor;
 
-  @Inject
   DynamicConfigService(Registry registry, Config config) {
     this.lastUpdateTime = PolledMeter.using(registry)
         .withName("iep.archaius.cacheAge")

--- a/iep-spring-dynconfig/src/main/java/com/netflix/iep/dynconfig/PropsEndpoint.java
+++ b/iep-spring-dynconfig/src/main/java/com/netflix/iep/dynconfig/PropsEndpoint.java
@@ -20,7 +20,6 @@ import com.netflix.iep.config.DynamicConfigManager;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
 
-import javax.inject.Inject;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -32,7 +31,6 @@ public class PropsEndpoint implements HttpEndpoint {
 
   private final DynamicConfigManager manager;
 
-  @Inject
   public PropsEndpoint(DynamicConfigManager manager) {
     this.manager = manager;
   }

--- a/iep-spring-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderDatabase.java
+++ b/iep-spring-leader-dynamodb/src/main/java/com/netflix/iep/leader/dynamodb/DynamoDbLeaderDatabase.java
@@ -39,8 +39,6 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import software.amazon.awssdk.services.dynamodb.model.TableStatus;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -49,7 +47,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-@Singleton
 public class DynamoDbLeaderDatabase implements LeaderDatabase {
 
   public static class TableActiveTimeoutException extends RuntimeException {
@@ -93,7 +90,6 @@ public class DynamoDbLeaderDatabase implements LeaderDatabase {
   private final String removeLeadershipExpression;
   private final String removeLeadershipConditionExpression;
 
-  @Inject
   public DynamoDbLeaderDatabase(DynamoDbClient db, Config config) {
     this(
         db,

--- a/iep-spring-leader/src/main/java/com/netflix/iep/leader/LeaderService.java
+++ b/iep-spring-leader/src/main/java/com/netflix/iep/leader/LeaderService.java
@@ -28,15 +28,12 @@ import com.typesafe.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * {@code LeaderService} manages periodic leader election using the provided {@link LeaderElector}.
  */
-@Singleton
 public class LeaderService extends AbstractService {
 
   private static final Logger logger = LoggerFactory.getLogger(LeaderService.class);
@@ -54,7 +51,6 @@ public class LeaderService extends AbstractService {
 
   private volatile boolean running = false;
 
-  @Inject
   public LeaderService(LeaderElector leaderElector, Config config, Registry registry) {
     this(
         leaderElector,

--- a/iep-spring-spectatord/src/main/java/com/netflix/iep/spectatord/SidecarRegistryService.java
+++ b/iep-spring-spectatord/src/main/java/com/netflix/iep/spectatord/SidecarRegistryService.java
@@ -28,8 +28,6 @@ import com.typesafe.config.ConfigFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Singleton;
-
 /**
  * Service for StatelessRegistry that reports to Atlas aggregator endpoint. If using
  * an add on to Guice that supports lifecycle, then the service will get started and
@@ -37,7 +35,6 @@ import javax.inject.Singleton;
  * then the registry will be started when accessed, but never stopped. This means that
  * the final metrics during shutdown may not get reported correctly.
  */
-@Singleton
 class SidecarRegistryService extends AbstractService {
 
   private static Config defaultConfig() {

--- a/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/CompositeUserService.java
+++ b/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/CompositeUserService.java
@@ -17,8 +17,6 @@ package com.netflix.iep.userservice;
 
 import com.netflix.iep.service.AbstractService;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
@@ -28,12 +26,10 @@ import java.util.TreeSet;
  * Combines a set of other user services into a combined view. It is assumed
  * that there is no overlap in the data sets.
  */
-@Singleton
 class CompositeUserService extends AbstractService implements UserService {
 
   private final Set<UserService> services;
 
-  @Inject
   CompositeUserService(Set<UserService> services) {
     this.services = services;
   }

--- a/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/Context.java
+++ b/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/Context.java
@@ -22,8 +22,6 @@ import com.netflix.spectator.ipc.http.HttpRequestBuilder;
 import com.netflix.spectator.ipc.http.HttpResponse;
 import com.typesafe.config.Config;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.URI;
@@ -32,7 +30,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /** Common settings used across all services. */
-@Singleton
 public final class Context implements AutoCloseable {
 
   private final ObjectMapper mapper = new ObjectMapper();
@@ -51,7 +48,6 @@ public final class Context implements AutoCloseable {
 
   private final ScheduledExecutorService executor;
 
-  @Inject
   public Context(Registry registry, Config config, HttpClient client, SSLSocketFactory sslFactory) {
     this.registry = registry;
     this.config = config.getConfig("netflix.iep.userservice");

--- a/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/HttpUserService.java
+++ b/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/HttpUserService.java
@@ -21,8 +21,6 @@ import com.netflix.iep.service.AbstractService;
 import com.netflix.spectator.ipc.http.HttpResponse;
 import com.typesafe.config.Config;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +32,6 @@ import java.util.Set;
  * supported call is {@link #isValidEmail(String)}, the others just return an empty set.
  * Email checks will get cached to reduce load and improve performance for repeated checks.
  */
-@Singleton
 public class HttpUserService extends AbstractService implements UserService {
 
   private final Context context;
@@ -43,7 +40,6 @@ public class HttpUserService extends AbstractService implements UserService {
 
   private final LoadingCache<String, Boolean> cache;
 
-  @Inject
   HttpUserService(Context context) {
     this(context, "http");
   }

--- a/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/UserServiceEndpoint.java
+++ b/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/UserServiceEndpoint.java
@@ -17,7 +17,6 @@ package com.netflix.iep.userservice;
 
 import com.netflix.iep.admin.HttpEndpoint;
 
-import javax.inject.Inject;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -35,7 +34,6 @@ public class UserServiceEndpoint implements HttpEndpoint {
 
   private final UserService service;
 
-  @Inject
   public UserServiceEndpoint(UserService service) {
     this.service = service;
   }

--- a/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/WhitelistUserService.java
+++ b/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/WhitelistUserService.java
@@ -18,8 +18,6 @@ package com.netflix.iep.userservice;
 import com.netflix.iep.service.AbstractService;
 import com.typesafe.config.Config;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,13 +28,11 @@ import java.util.TreeSet;
  * Service based on an explicit list if addresses and mappings provided in the
  * config.
  */
-@Singleton
 class WhitelistUserService extends AbstractService implements UserService {
 
   private final Set<String> emails;
   private final Map<String, String> mappings;
 
-  @Inject
   WhitelistUserService(Context context) {
     Config config = context.config().getConfig("whitelist");
     emails = Collections.unmodifiableSet(new TreeSet<>(config.getStringList("emails")));

--- a/iep-spring/src/main/java/com/netflix/iep/spring/Args.java
+++ b/iep-spring/src/main/java/com/netflix/iep/spring/Args.java
@@ -15,7 +15,6 @@
  */
 package com.netflix.iep.spring;
 
-import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -38,12 +37,6 @@ public class Args implements Iterable<String> {
 
   private Args(List<String> argv) {
     this.argv = argv;
-  }
-
-  // Needed to all just-in-time binding to work if no explicit argument binding is set.
-  @Inject
-  private Args() {
-    this(Collections.emptyList());
   }
 
   /** Return the argument at the specified position. */

--- a/iep-spring/src/main/java/com/netflix/iep/spring/IepConfiguration.java
+++ b/iep-spring/src/main/java/com/netflix/iep/spring/IepConfiguration.java
@@ -22,7 +22,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.inject.Provider;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -40,11 +39,6 @@ public class IepConfiguration {
   @Bean
   ServiceManager serviceManager(Set<Service> services) {
     return new ServiceManager(services);
-  }
-
-  @Bean
-  Provider<ServiceManager> serviceManagerProvider(ApplicationContext context) {
-    return () -> context.getBean(ServiceManager.class);
   }
 
   @Bean

--- a/iep-spring/src/main/java/com/netflix/iep/spring/SpringClassFactory.java
+++ b/iep-spring/src/main/java/com/netflix/iep/spring/SpringClassFactory.java
@@ -20,14 +20,10 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.ResolvableType;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.lang.reflect.ParameterizedType;
 
-@Singleton
 class SpringClassFactory extends DefaultClassFactory {
 
-  @Inject
   SpringClassFactory(ApplicationContext context) {
     super(type -> {
       try {

--- a/iep-spring/src/test/java/com/netflix/iep/spring/LifecycleTest.java
+++ b/iep-spring/src/test/java/com/netflix/iep/spring/LifecycleTest.java
@@ -26,8 +26,6 @@ import org.springframework.context.annotation.Scope;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 @RunWith(JUnit4.class)
 public class LifecycleTest {
@@ -146,7 +144,6 @@ public class LifecycleTest {
   public static class StateObjectConfiguration {
 
     @Bean
-    @Singleton
     StateObject stateObject() {
       return new StateObject();
     }
@@ -157,7 +154,6 @@ public class LifecycleTest {
 
     private State state;
 
-    @Inject
     StateObject() {
       state = State.INIT;
     }
@@ -177,12 +173,10 @@ public class LifecycleTest {
     }
   }
 
-  @Singleton
   private static class AutoStateObject implements AutoCloseable {
 
     private State state;
 
-    @Inject
     AutoStateObject() {
       state = State.STARTED;
     }
@@ -197,12 +191,10 @@ public class LifecycleTest {
   }
 
 
-  @Singleton
   private static class InjectedStateObject {
 
     private StateObject obj;
 
-    @Inject
     InjectedStateObject(StateObject obj) {
       this.obj = obj;
       Assert.assertEquals(State.STARTED, obj.getState());

--- a/iep-spring/src/test/java/com/netflix/iep/spring/SpringClassFactoryTest.java
+++ b/iep-spring/src/test/java/com/netflix/iep/spring/SpringClassFactoryTest.java
@@ -26,11 +26,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
-import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Provider;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 @RunWith(JUnit4.class)
 public class SpringClassFactoryTest {
@@ -70,17 +69,17 @@ public class SpringClassFactoryTest {
   }
 
   @Test
-  public void provider() throws Exception {
+  public void supplier() throws Exception {
     try (AnnotationConfigApplicationContext context = createContext()) {
-      context.register(ProviderClassConfiguration.class);
-      context.registerBean(ProviderClass.class);
+      context.register(SupplierClassConfiguration.class);
+      context.registerBean(SupplierClass.class);
       context.registerBean(TestClass.class);
-      context.registerBean(WithProvider.class);
+      context.registerBean(WithSupplier.class);
       context.registerBean(String.class, () -> "foo");
       context.refresh();
       context.start();
 
-      WithProvider obj = context.getBean(WithProvider.class);
+      WithSupplier obj = context.getBean(WithSupplier.class);
       Assert.assertEquals("foo", obj.configClass.v.get());
     }
   }
@@ -119,7 +118,6 @@ public class SpringClassFactoryTest {
   public static class Normal {
     final TestClass configClass;
 
-    @Inject
     public Normal(ClassFactory factory) throws Exception {
       // Class name from configuration settings
       final String cname = TestClass.class.getName();
@@ -130,7 +128,6 @@ public class SpringClassFactoryTest {
   public static class WithOverride {
     final TestClass configClass;
 
-    @Inject
     public WithOverride(ClassFactory factory) throws Exception {
       // Class name from configuration settings
       final String cname = TestClass.class.getName();
@@ -140,13 +137,12 @@ public class SpringClassFactoryTest {
     }
   }
 
-  public static class WithProvider {
-    final ProviderClass configClass;
+  public static class WithSupplier {
+    final SupplierClass configClass;
 
-    @Inject
-    public WithProvider(ClassFactory factory) throws Exception {
+    public WithSupplier(ClassFactory factory) throws Exception {
       // Class name from configuration settings
-      final String cname = ProviderClass.class.getName();
+      final String cname = SupplierClass.class.getName();
       configClass = factory.newInstance(cname);
     }
   }
@@ -154,26 +150,24 @@ public class SpringClassFactoryTest {
   public static class TestClass {
     final String v;
 
-    @Inject
     public TestClass(String v) {
       this.v = v;
     }
   }
 
   @Configuration
-  public static class ProviderClassConfiguration {
+  public static class SupplierClassConfiguration {
 
     @Bean
-    Provider<String> stringValue(ApplicationContext context) {
+    Supplier<String> stringValue(ApplicationContext context) {
       return () -> context.getBean(String.class);
     }
   }
 
-  public static class ProviderClass {
-    final Provider<String> v;
+  public static class SupplierClass {
+    final Supplier<String> v;
 
-    @Inject
-    public ProviderClass(Provider<String> v) {
+    public SupplierClass(Supplier<String> v) {
       this.v = v;
     }
   }
@@ -191,7 +185,6 @@ public class SpringClassFactoryTest {
   public static class Wrapper {
     final String s2;
 
-    @Inject
     public Wrapper(@Named("s2") String s2) {
       this.s2 = s2;
     }

--- a/iep-spring/src/test/java/com/netflix/iep/spring/TestService.java
+++ b/iep-spring/src/test/java/com/netflix/iep/spring/TestService.java
@@ -17,13 +17,10 @@ package com.netflix.iep.spring;
 
 import com.netflix.iep.service.AbstractService;
 
-import javax.inject.Inject;
-
 public class TestService extends AbstractService {
 
   private boolean healthy = false;
 
-  @Inject
   public TestService(Args args) {
     if (args.isEmpty()) {
       throw new IllegalArgumentException("missing required argument");


### PR DESCRIPTION
Removes the `@Singleton` and `@Inject` annotations that are no longer needed with how we are using Spring. This will make it easier to transition to Spring 6 in the future.