### PR TITLE
cleanup config for spectatord

### DIFF
--- a/iep-spring-spectatord/src/main/resources/reference.conf
+++ b/iep-spring-spectatord/src/main/resources/reference.conf
@@ -1,8 +1,7 @@
 
 netflix.iep.atlas.sidecar {
 
-  frequency = PT5S
-  uri = "http://localhost:7101/api/v4/update"
+  output-location = "udp://127.0.0.1:1234"
 
   collection {
     jvm = true


### PR DESCRIPTION
Remove unused configuration settings and include the output location so it is clear how to override if
needed.