### PR TITLE
spring: update ClassFactory to support qualifiers

### DIFF
--- a/iep-spring/src/main/java/com/netflix/iep/spring/SpringClassFactory.java
+++ b/iep-spring/src/main/java/com/netflix/iep/spring/SpringClassFactory.java
@@ -15,32 +15,86 @@
  */
 package com.netflix.iep.spring;
 
-import com.netflix.iep.service.DefaultClassFactory;
+import com.netflix.iep.service.ClassFactory;
+import com.netflix.iep.service.CreationException;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.DependencyDescriptor;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.ResolvableType;
+import org.springframework.core.MethodParameter;
 
-import java.lang.reflect.ParameterizedType;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Type;
+import java.util.function.Function;
 
-class SpringClassFactory extends DefaultClassFactory {
+class SpringClassFactory implements ClassFactory {
+
+  private final ApplicationContext context;
+  private final DefaultListableBeanFactory factory;
 
   SpringClassFactory(ApplicationContext context) {
-    super(type -> {
-      try {
-        if (type instanceof Class<?>) {
-          return context.getBean((Class<?>) type);
-        } else if (type instanceof ParameterizedType) {
-          ResolvableType rt = ResolvableType.forType(type);
-          String[] beanNames = context.getBeanNamesForType(rt);
-          return beanNames.length == 0
-              ? null
-              : context.getBean(beanNames[0]);
-        } else {
-          return null;
+    this.context = context;
+    BeanFactory bf = context.getAutowireCapableBeanFactory();
+    this.factory = (bf instanceof DefaultListableBeanFactory)
+        ? (DefaultListableBeanFactory) bf
+        : null;
+  }
+
+  @Override public <T> T newInstance(Type type, Function<Type, Object> overrides)
+      throws CreationException {
+    Class<?> cls = (Class<?>) type;
+    Constructor<?>[] constructors = cls.getDeclaredConstructors();
+    if (constructors.length == 1) {
+      Constructor<?> c = constructors[0];
+      Type[] ptypes = c.getGenericParameterTypes();
+      Object[] pvalues = new Object[ptypes.length];
+      Annotation[][] annos = c.getParameterAnnotations();
+      for (int i = 0; i < pvalues.length; ++i) {
+        Object value = overrides.apply(ptypes[i]);
+        if (value == null) {
+          MethodParameter parameter = new MethodParameter(c, i);
+          value = getBeanForType(parameter);
         }
-      } catch (NoSuchBeanDefinitionException e) {
-        return null;
+        pvalues[i] = value;
       }
-    });
+      return newInstance(cls, c, pvalues);
+    } else {
+      for (Constructor<?> c : constructors) {
+        Type[] ptypes = c.getGenericParameterTypes();
+        if (ptypes.length == 0) {
+          return newInstance(cls, c);
+        }
+      }
+      throw new CreationException("class " + cls.getCanonicalName() +
+          " has more than one constructor and does not have a no-argument constructor");
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T newInstance(Type type, Constructor<?> ctor, Object... values)
+      throws CreationException {
+    try {
+      ctor.setAccessible(true);
+      return (T) ctor.newInstance(values);
+    } catch (Exception e) {
+      throw new CreationException(type, e);
+    }
+  }
+
+  private Object getBeanForType(MethodParameter parameter) {
+    try {
+      DependencyDescriptor descriptor = new DependencyDescriptor(parameter, true, false);
+      if (factory != null) {
+        // Needed to resolve qualifiers
+        return factory.resolveDependency(descriptor, null);
+      } else {
+        // If factory type is wrong, then just try based on type
+        return context.getBean(parameter.getParameterType());
+      }
+    } catch (NoSuchBeanDefinitionException e) {
+      return null;
+    }
   }
 }

--- a/iep-spring/src/test/java/com/netflix/iep/spring/SpringClassFactoryTest.java
+++ b/iep-spring/src/test/java/com/netflix/iep/spring/SpringClassFactoryTest.java
@@ -99,6 +99,19 @@ public class SpringClassFactoryTest {
     }
   }
 
+  @Test
+  public void directQualifier() throws Exception {
+    try (AnnotationConfigApplicationContext context = createContext()) {
+      context.register(StringConfiguration.class);
+      context.registerBean(Wrapper.class);
+      context.refresh();
+      context.start();
+
+      Wrapper obj = context.getBean(ClassFactory.class).newInstance(Wrapper.class);
+      Assert.assertEquals("2", obj.s2);
+    }
+  }
+
   @Configuration
   public static class StringConfiguration {
 


### PR DESCRIPTION
Improve the `SpringClassFactory` to honor qualifier annotations used in the constructor parameters.

Backport of #569 to the v4 branch.