### PR TITLE
admin: option to limit to localhost

### DIFF
--- a/iep-admin/src/main/java/com/netflix/iep/admin/AdminConfig.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/AdminConfig.java
@@ -31,6 +31,10 @@ public interface AdminConfig {
   AdminConfig DEFAULT = new AdminConfig() {
     private final Config cfg = ConfigManager.get().getConfig("netflix.iep.admin");
 
+    @Override public String listenOn() {
+      return cfg.getString("listen-on");
+    }
+
     @Override public int port() {
       return cfg.getInt("port");
     }
@@ -47,6 +51,9 @@ public interface AdminConfig {
       return cfg.getString("ui-location");
     }
   };
+
+  /** Host for the server to listen on. */
+  String listenOn();
 
   /** Port to use for the admin server. */
   int port();

--- a/iep-admin/src/main/java/com/netflix/iep/admin/AdminServer.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/AdminServer.java
@@ -22,7 +22,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +48,12 @@ public class AdminServer implements AutoCloseable {
     return endpoints;
   }
 
+  static InetSocketAddress resolve(String host, int port) throws UnknownHostException {
+    return "*".equals(host)
+        ? new InetSocketAddress(port)
+        : new InetSocketAddress(InetAddress.getByName(host), port);
+  }
+
   private final AdminConfig config;
   private final HttpServer server;
 
@@ -57,7 +65,7 @@ public class AdminServer implements AutoCloseable {
       throws IOException {
     this.config = config;
 
-    InetSocketAddress address = new InetSocketAddress(config.port());
+    InetSocketAddress address = resolve(config.listenOn(), config.port());
     this.server = HttpServer.create(address, config.backlog());
 
     TreeSet<String> paths = new TreeSet<>(endpoints.keySet());

--- a/iep-admin/src/main/resources/reference.conf
+++ b/iep-admin/src/main/resources/reference.conf
@@ -1,7 +1,19 @@
 
 netflix.iep.admin {
+  // Restrict which hosts the server listens on. For improved security it can be limited to
+  // localhost. Use "*" to listen on any local address.
+  listen-on = "localhost"
+
+  // Port for the admin service
   port = 8077
+
+  // Server socket backlog
+  // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/ServerSocket.html#%3Cinit%3E(int,int)
   backlog = 10
+
+  // How long to give existing requests to complete before shutting down the server
   shutdown-delay = 0s
+
+  // Path to redirect to for the UI
   ui-location = "/ui"
 }

--- a/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
@@ -160,7 +160,6 @@ public class AdminServerTest {
   public void resolveLocalhost() throws Exception {
     InetSocketAddress addr = AdminServer.resolve("localhost", 12345);
     Assert.assertTrue(addr.getAddress().isLoopbackAddress());
-    System.out.println(addr.getAddress().getClass().getSimpleName());
   }
 
   @Test

--- a/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
@@ -26,6 +26,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URL;
@@ -53,6 +56,10 @@ public class AdminServerTest {
   public void before() throws IOException {
     port = getUnusedPort();
     AdminConfig config = new AdminConfig() {
+      @Override public String listenOn() {
+        return null;
+      }
+
       @Override public int port() {
         return port;
       }
@@ -135,6 +142,39 @@ public class AdminServerTest {
 
   private Response httpOptions(String path, Map<String, String> headers) throws Exception {
     return http("OPTIONS", path, headers);
+  }
+
+  @Test
+  public void resolveNull() throws Exception {
+    InetSocketAddress addr = AdminServer.resolve(null, 12345);
+    Assert.assertTrue(addr.getAddress().isLoopbackAddress());
+  }
+
+  @Test
+  public void resolveAny() throws Exception {
+    InetSocketAddress addr = AdminServer.resolve("*", 12345);
+    Assert.assertTrue(addr.getAddress().isAnyLocalAddress());
+  }
+
+  @Test
+  public void resolveLocalhost() throws Exception {
+    InetSocketAddress addr = AdminServer.resolve("localhost", 12345);
+    Assert.assertTrue(addr.getAddress().isLoopbackAddress());
+    System.out.println(addr.getAddress().getClass().getSimpleName());
+  }
+
+  @Test
+  public void resolveLocalhostV4() throws Exception {
+    InetSocketAddress addr = AdminServer.resolve("127.0.0.1", 12345);
+    Assert.assertTrue(addr.getAddress().isLoopbackAddress());
+    Assert.assertTrue(addr.getAddress() instanceof Inet4Address);
+  }
+
+  @Test
+  public void resolveLocalhostV6() throws Exception {
+    InetSocketAddress addr = AdminServer.resolve("::1", 12345);
+    Assert.assertTrue(addr.getAddress().isLoopbackAddress());
+    Assert.assertTrue(addr.getAddress() instanceof Inet6Address);
   }
 
   @Test


### PR DESCRIPTION
Add an option to specify the address to listen on. Before it would listen on any local address and could be accessed remotely. Now it will default to only listen on localhost.