### PR TITLE
aws: add option to enable dualstack

### DIFF
--- a/iep-spring-aws2/src/main/resources/reference.conf
+++ b/iep-spring-aws2/src/main/resources/reference.conf
@@ -39,7 +39,18 @@ netflix.iep.aws {
       //user-agent-prefix
       //user-agent-suffix
     }
+
+    // Should dualstack be enabled for the client?
+    // https://docs.aws.amazon.com/vpc/latest/userguide/aws-ipv6-support.html
+    dualstack = false
   }
+
+  // Overrides for services that support IPv6 to use dualstack
+  // https://docs.aws.amazon.com/vpc/latest/userguide/aws-ipv6-support.html
+  ec2.dualstack = true
+  elasticloadbalancingv2.dualstack = true
+  route53.dualstack = true
+  s3.dualstack = true
 
   // http://docs.aws.amazon.com/general/latest/gr/rande.html
   // This is used to set overrides when a service is not available locally in the


### PR DESCRIPTION
Adds a new config option to enable dualstack on the AWS client. For services we commonly use that support dualstack, it is enabled by default.