### PR TITLE
aws: limit dual-stack to allowed regions

### DIFF
--- a/iep-spring-aws2/src/main/resources/reference.conf
+++ b/iep-spring-aws2/src/main/resources/reference.conf
@@ -43,6 +43,18 @@ netflix.iep.aws {
     // Should dualstack be enabled for the client?
     // https://docs.aws.amazon.com/vpc/latest/userguide/aws-ipv6-support.html
     dualstack = false
+
+    // Unfortunately, AWS doesn't have consistent support for dualstack across all
+    // regions. Add list of supported regions.
+    // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Using_Endpoints.html#ipv6
+    dualstack-regions = [
+      "ap-south-1",
+      "eu-west-1",
+      "sa-east-1",
+      "us-east-1",
+      "us-east-2",
+      "us-west-2"
+    ]
   }
 
   // Overrides for services that support IPv6 to use dualstack


### PR DESCRIPTION
Add config with the set of regions where dual-stack endpoints are actually available. This needs to be done in addition to checking if the various services actually support it.