### PR TITLE
aws: adjust dualstack defaults

### DIFF
--- a/iep-spring-aws2/src/main/resources/reference.conf
+++ b/iep-spring-aws2/src/main/resources/reference.conf
@@ -59,9 +59,8 @@ netflix.iep.aws {
 
   // Overrides for services that support IPv6 to use dualstack
   // https://docs.aws.amazon.com/vpc/latest/userguide/aws-ipv6-support.html
+  // So far EC2 and S3 are the only services confirmed to support dualstack.
   ec2.dualstack = true
-  elasticloadbalancingv2.dualstack = true
-  route53.dualstack = true
   s3.dualstack = true
 
   // http://docs.aws.amazon.com/general/latest/gr/rande.html


### PR DESCRIPTION
The AWS docs for IPv6 are a bit confusing and not in a single place. For the dualstack API endpoints EC2 and S3 are the only ones that seem to work at this time.