### PR TITLE
disable Atlas binding when using SBN3

### DIFF
--- a/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/NoSbnCondition.java
+++ b/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/NoSbnCondition.java
@@ -26,7 +26,8 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 class NoSbnCondition implements Condition {
   @Override
   public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
-    String v = context.getEnvironment().getProperty("management.metrics.export.atlas.enabled");
-    return v == null;
+    String sbn2 = context.getEnvironment().getProperty("management.metrics.export.atlas.enabled");
+    String sbn3 = context.getEnvironment().getProperty("management.atlas.metrics.export.enabled");
+    return sbn2 == null && sbn3 == null;
   }
 }

--- a/iep-spring-atlas/src/test/java/com/netflix/iep/atlas/AtlasConfigurationTest.java
+++ b/iep-spring-atlas/src/test/java/com/netflix/iep/atlas/AtlasConfigurationTest.java
@@ -43,9 +43,24 @@ public class AtlasConfigurationTest {
   }
 
   @Test(expected = NoSuchBeanDefinitionException.class)
-  public void registryIsNotBoundIfSbnIsPresent() {
+  public void registryIsNotBoundIfSbn2IsPresent() {
     Map<String, Object> props = new HashMap<>();
     props.put("management.metrics.export.atlas.enabled", "true");
+    try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+      context.getEnvironment()
+          .getPropertySources()
+          .addFirst(new MapPropertySource("test", props));
+      context.register(AtlasConfiguration.class);
+      context.refresh();
+      context.start();
+      context.getBean(Registry.class);
+    }
+  }
+
+  @Test(expected = NoSuchBeanDefinitionException.class)
+  public void registryIsNotBoundIfSbn3IsPresent() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("management.atlas.metrics.export.enabled", "true");
     try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
       context.getEnvironment()
           .getPropertySources()


### PR DESCRIPTION
The property name the SBN check uses changed in SBN3. Update it to check for both variants.