### PR TITLE
servergrous: support v6 only instances

### DIFF
--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EddaLoader.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EddaLoader.java
@@ -95,7 +95,7 @@ public class EddaLoader implements Loader {
     JsonUtils.forEach(jp, p -> {
       try {
         vs.add(decodeInstance(jp));
-      } catch (NullPointerException e) {
+      } catch (IllegalArgumentException | NullPointerException e) {
         // Log but otherwise ignore failures like missing IP address
         LOGGER.warn("failed to process instance in Edda response", e);
       }

--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EurekaLoader.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EurekaLoader.java
@@ -89,6 +89,9 @@ public class EurekaLoader implements Loader {
             JsonUtils.skipValue(p);
           }
           break;
+        case "ipv6":
+          info.builder.ipv6Address(JsonUtils.stringValue(p));
+          break;
         case "instance-id":
           info.node = JsonUtils.stringValue(p);
           break;

--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/Instance.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/Instance.java
@@ -26,6 +26,7 @@ public final class Instance {
 
   private final String node;
   private final String privateIpAddress;
+  private final String ipv6Address;
 
   private final String vpcId;
   private final String subnetId;
@@ -39,6 +40,7 @@ public final class Instance {
   private Instance(Builder builder) {
     node = builder.node;
     privateIpAddress = builder.privateIpAddress;
+    ipv6Address = builder.ipv6Address;
     vpcId = builder.vpcId;
     subnetId = builder.subnetId;
     ami = builder.ami;
@@ -102,6 +104,7 @@ public final class Instance {
     return builder()
         .node(node)
         .privateIpAddress(orElse(privateIpAddress, other.privateIpAddress))
+        .ipv6Address(orElse(ipv6Address, other.ipv6Address))
         .vpcId(orElse(vpcId, other.vpcId))
         .subnetId(orElse(subnetId, other.subnetId))
         .ami(orElse(ami, other.ami))
@@ -121,6 +124,7 @@ public final class Instance {
     Instance instance = (Instance) o;
     return Objects.equals(node, instance.node) &&
         Objects.equals(privateIpAddress, instance.privateIpAddress) &&
+        Objects.equals(ipv6Address, instance.ipv6Address) &&
         Objects.equals(vpcId, instance.vpcId) &&
         Objects.equals(subnetId, instance.subnetId) &&
         Objects.equals(ami, instance.ami) &&
@@ -130,13 +134,14 @@ public final class Instance {
   }
 
   @Override public int hashCode() {
-    return Objects.hash(node, privateIpAddress, vpcId, subnetId, ami, vmtype, zone, status);
+    return Objects.hash(node, privateIpAddress, ipv6Address, vpcId, subnetId, ami, vmtype, zone, status);
   }
 
   @Override public String toString() {
     return "Instance("
         + "node=" + node + ", "
         + "privateIpAddress=" + privateIpAddress + ", "
+        + "ipv6Address=" + ipv6Address + ", "
         + "vpcId=" + vpcId + ", "
         + "subnetId=" + subnetId + ", "
         + "ami=" + ami + ", "
@@ -155,6 +160,7 @@ public final class Instance {
   public static class Builder {
     private String node;
     private String privateIpAddress;
+    private String ipv6Address;
     private String vpcId;
     private String subnetId;
     private String ami;
@@ -171,9 +177,15 @@ public final class Instance {
       return this;
     }
 
-    /** Set the IP address. This attribute is required. */
+    /** Set the IP address. An instance must have either a private IP or IPv6 address. */
     public Builder privateIpAddress(String value) {
       privateIpAddress = value;
+      return this;
+    }
+
+    /** Set the IPv6 address. An instance must have either a private IP or IPv6 address. */
+    public Builder ipv6Address(String value) {
+      ipv6Address = value;
       return this;
     }
 
@@ -216,7 +228,9 @@ public final class Instance {
     /** Create an instance from this builder. */
     public Instance build() {
       Preconditions.checkNotNull(node, "node must be set");
-      Preconditions.checkNotNull(privateIpAddress, "privateIpAddress must be set");
+      if (privateIpAddress == null && ipv6Address == null) {
+        throw new IllegalArgumentException("no IP address for instance");
+      }
       if (status == null) {
         status = Status.NOT_REGISTERED;
       }

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EurekaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EurekaLoaderTest.java
@@ -81,7 +81,20 @@ public class EurekaLoaderTest {
   @Test
   public void preferIpAddrToMetadataLocalIp() throws Exception {
     List<ServerGroup> expected = new ArrayList<>();
-    expected.add(defaultEc2Group()); // metadata has 10.20.30.42
+    expected.add(ServerGroup.builder()
+        .platform("ec2")
+        .group("app-main-v001")
+        .addInstance(Instance.builder()
+            .node("i-1234567890")
+            .privateIpAddress("10.20.30.40")
+            .ipv6Address("::ffff:a14:1e2a")
+            .vpcId("vpc-54321")
+            .ami("ami-0987654321")
+            .vmtype("m5.large")
+            .zone("us-east-1d")
+            .status(Instance.Status.UP)
+            .build())
+        .build()); // metadata has 10.20.30.42
     List<ServerGroup> actual = get("eureka-ip.json", "12345");
     Assert.assertEquals(expected, actual);
   }

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/InstanceTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/InstanceTest.java
@@ -38,8 +38,8 @@ public class InstanceTest {
         .build();
   }
 
-  @Test(expected = NullPointerException.class)
-  public void missingPrivateIp() {
+  @Test(expected = IllegalArgumentException.class)
+  public void missingIp() {
     Instance.builder()
         .node("i-12345")
         .build();
@@ -174,6 +174,25 @@ public class InstanceTest {
       Instance i2 = Instance.builder()
           .node("i-12345")
           .privateIpAddress("1.2.3.4")
+          .status(statuses[i])
+          .build();
+      Instance merged = i1.merge(i2);
+      Assert.assertEquals(i2, merged);
+    }
+  }
+
+  @Test
+  public void mergeIPv6() {
+    Instance.Status[] statuses = Instance.Status.values();
+    for (int i = 1; i < statuses.length; ++i) {
+      Instance i1 = Instance.builder()
+          .node("i-12345")
+          .ipv6Address("::1")
+          .status(statuses[i - 1])
+          .build();
+      Instance i2 = Instance.builder()
+          .node("i-12345")
+          .ipv6Address("::1")
           .status(statuses[i])
           .build();
       Instance merged = i1.merge(i2);

--- a/iep-servergroups/src/test/resources/eureka-ip.json
+++ b/iep-servergroups/src/test/resources/eureka-ip.json
@@ -28,7 +28,8 @@
                 "accountId": "12345",
                 "public-hostname": "10.20.30.40",
                 "vpc-id": "vpc-54321",
-                "local-ipv4": "10.20.30.42"
+                "local-ipv4": "10.20.30.42",
+                "ipv6": "::ffff:a14:1e2a"
               }
             },
             "hostName": "10.20.30.40",


### PR DESCRIPTION
Update to support Edda instances that only have IPv6 addresses and do not have a private IP address.