### PR TITLE
servergroups: extract IPv6 from Edda response

### DIFF
--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EddaLoader.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EddaLoader.java
@@ -63,6 +63,9 @@ public class EddaLoader implements Loader {
         case "privateIpAddress":
           builder.privateIpAddress(JsonUtils.stringValue(jp));
           break;
+        case "ipv6Address":
+          builder.ipv6Address(JsonUtils.stringValue(jp));
+          break;
         case "vpcId":
           builder.vpcId(JsonUtils.stringValue(jp));
           break;

--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/Instance.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/Instance.java
@@ -229,7 +229,6 @@ public final class Instance {
     public Instance build() {
       Preconditions.checkNotNull(node, "node must be set");
       if (privateIpAddress == null && ipv6Address == null) {
-        System.out.printf("%s %s %s%n", node, privateIpAddress, ipv6Address);
         throw new IllegalArgumentException("no IP address for instance");
       }
       if (status == null) {

--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/Instance.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/Instance.java
@@ -229,6 +229,7 @@ public final class Instance {
     public Instance build() {
       Preconditions.checkNotNull(node, "node must be set");
       if (privateIpAddress == null && ipv6Address == null) {
+        System.out.printf("%s %s %s%n", node, privateIpAddress, ipv6Address);
         throw new IllegalArgumentException("no IP address for instance");
       }
       if (status == null) {

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
@@ -62,6 +62,31 @@ public class EddaLoaderTest {
   }
 
   @Test
+  public void ipv6Group() throws Exception {
+    List<ServerGroup> expected = new ArrayList<>();
+    expected.add(ServerGroup.builder()
+        .platform("ec2")
+        .group("app-main-dev-v001")
+        .minSize(1)
+        .maxSize(3)
+        .desiredSize(2)
+        .addInstance(Instance.builder()
+            .node("i-1234567890")
+            .privateIpAddress("10.20.30.40")
+            .ipv6Address("::ffff:a14:1e2a")
+            .vpcId("vpc-54321")
+            .subnetId("subnet-54321")
+            .ami("ami-0987654321")
+            .vmtype("m5.large")
+            .zone("us-east-1d")
+            .status(Instance.Status.NOT_REGISTERED)
+            .build())
+        .build());
+    List<ServerGroup> actual = get("edda-ipv6.json");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void ec2GroupGzip() throws Exception {
     List<ServerGroup> expected = new ArrayList<>();
     expected.add(defaultEc2Group());

--- a/iep-servergroups/src/test/resources/edda-ipv6.json
+++ b/iep-servergroups/src/test/resources/edda-ipv6.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "ec2.app-main-dev-v001",
+    "platform": "ec2",
+    "app": "app",
+    "foo": ["bar", "baz", {"abc":  ["def", {}]}],
+    "cluster": "app-main-dev",
+    "group": "app-main-dev-v001",
+    "stack": "main",
+    "detail": "dev",
+    "minSize": 1,
+    "maxSize": 3,
+    "desiredSize": 2,
+    "instances": [
+      {
+        "launchTime": 1544328558000,
+        "node": "i-1234567890",
+        "privateIpAddress": "10.20.30.40",
+        "ipv6Address": "::ffff:a14:1e2a",
+        "vpcId": "vpc-54321",
+        "subnetId": "subnet-54321",
+        "ami": "ami-0987654321",
+        "vmtype": "m5.large",
+        "zone": "us-east-1d"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Update Edda parsing to get the IPv6 address for the instances in a server group.