### PR TITLE
admin: incrementally stream iterable response

### DIFF
--- a/iep-admin/src/main/java/com/netflix/iep/admin/HttpEntity.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/HttpEntity.java
@@ -17,35 +17,8 @@ package com.netflix.iep.admin;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Map;
 
-/**
- * Minimal implementation of a response.
- */
-class BasicHttpResponse implements HttpResponse {
+interface HttpEntity {
 
-  private final int status;
-  private final Map<String, String> headers;
-  private final HttpEntity entity;
-
-  BasicHttpResponse(int status, Map<String, String> headers, HttpEntity entity) {
-    this.status = status;
-    this.headers = headers;
-    this.entity = entity;
-  }
-
-  @Override
-  public int status() {
-    return status;
-  }
-
-  @Override
-  public Map<String, String> headers() {
-    return headers;
-  }
-
-  @Override
-  public void writeEntity(OutputStream out) throws IOException {
-    entity.write(out);
-  }
+  void write(OutputStream out) throws IOException;
 }

--- a/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/SpectatorEndpoint.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/SpectatorEndpoint.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * List measurements via Spectator. The path can be an Atlas query expression
@@ -56,8 +55,8 @@ public class SpectatorEndpoint implements HttpEndpoint {
   }
 
   @Override public Object get(String path) {
-    Query q = Query.parse(path);
-    return registry.stream()
+    final Query q = Query.parse(path);
+    return (Iterable<Object>) () -> registry.stream()
         .filter(m -> !m.hasExpired())
         .flatMap(m -> {
           List<Object> ms = new ArrayList<>();
@@ -73,7 +72,7 @@ public class SpectatorEndpoint implements HttpEndpoint {
           }
           return ms.stream();
         })
-        .collect(Collectors.toList());
+        .iterator();
   }
 
   private void add(Query q, Map<String, String> tags, List<Object> vs, Object obj) {

--- a/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -79,6 +80,7 @@ public class AdminServerTest {
     Set<EndpointMapping> mappings = new HashSet<>();
     mappings.add(new EndpointMapping("/bad", new BadEndpoint()));
     mappings.add(new EndpointMapping("/test", new TestEndpoint()));
+    mappings.add(new EndpointMapping("/iterable", new IterableEndpoint()));
     server = new AdminServer(config, mappings);
   }
 
@@ -233,6 +235,13 @@ public class AdminServerTest {
   }
 
   @Test
+  public void iterableEmpty() throws Exception {
+    Response res = httpGet("/iterable");
+    Assert.assertEquals(200, res.status);
+    Assert.assertEquals("[]", res.content);
+  }
+
+  @Test
   public void notFoundEndpoint() throws Exception {
     Response res = httpGet("/not-found");
     Assert.assertEquals(404, res.status);
@@ -301,7 +310,7 @@ public class AdminServerTest {
   public void resources() throws Exception {
     Response res = httpGet("/resources");
     Assert.assertEquals(200, res.status);
-    Assert.assertEquals("[\"bad\",\"resources\",\"test\"]", res.content);
+    Assert.assertEquals("[\"bad\",\"iterable\",\"resources\",\"test\"]", res.content);
     Assert.assertEquals(404, httpGet("/resources/test").status);
   }
 
@@ -328,6 +337,21 @@ public class AdminServerTest {
 
     public Object get(String path) {
       return path;
+    }
+  }
+
+  public static class IterableEndpoint {
+    public Object get() {
+      return Collections.emptyList();
+    }
+
+    public Object get(String path) {
+      List<Integer> values = new ArrayList<>();
+      int n = Integer.parseInt(path);
+      for (int i = 0; i < n; ++i) {
+        values.add(i);
+      }
+      return values;
     }
   }
 

--- a/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SpectatorEndpointTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SpectatorEndpointTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -47,20 +48,26 @@ public class SpectatorEndpointTest {
   }
 
   @SuppressWarnings("unchecked")
+  private <T> List<T> toList(Object obj) {
+    List<T> result = new ArrayList<>();
+    ((Iterable<T>) obj).forEach(result::add);
+    return result;
+  }
+
   private <T> List<T> get(String q) {
-    List<T> d1 = (List<T>) endpoint.get(q);
+    List<T> d1 = toList(endpoint.get(q));
 
     // Verify that toString on parsed query yields the same result
     SpectatorEndpoint.Query query = SpectatorEndpoint.Query.parse(q);
-    List<T> d2 = (List<T>) endpoint.get(query.toString());
+    List<T> d2 = toList(endpoint.get(query.toString()));
 
     Assert.assertEquals(d1, d2);
     return d1;
   }
 
-  @Test @SuppressWarnings("unchecked")
+  @Test
   public void get() {
-    List<Object> datapoints = (List<Object>) endpoint.get();
+    List<Object> datapoints = toList(endpoint.get());
     Assert.assertEquals(registry.stream().count(), datapoints.size());
   }
 


### PR DESCRIPTION
Update admin server to incrementally write the items for an iterable to the response rather than first encoding to a byte array in memory.