### PR TITLE
admin: use chunked response

### DIFF
--- a/iep-admin/src/main/java/com/netflix/iep/admin/RequestHandler.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/RequestHandler.java
@@ -110,7 +110,7 @@ class RequestHandler implements HttpHandler {
     if ("HEAD".equals(exchange.getRequestMethod())) {
       exchange.sendResponseHeaders(res.status(), -1L);
     } else {
-      exchange.sendResponseHeaders(res.status(), res.entity().length);
+      exchange.sendResponseHeaders(res.status(), 0);
       try (OutputStream out = exchange.getResponseBody()) {
         out.write(res.entity());
       }


### PR DESCRIPTION
Avoid creating an in-memory copy of the entity just to compute the length.