### PR TITLE
aws2: update to use RetryStrategy

### DIFF
--- a/iep-spring-aws2/src/test/java/com/netflix/iep/aws2/AwsClientFactoryTest.java
+++ b/iep-spring-aws2/src/test/java/com/netflix/iep/aws2/AwsClientFactoryTest.java
@@ -287,7 +287,7 @@ public class AwsClientFactoryTest {
     ClientOverrideConfiguration settings = factory.createClientConfig(cfg);
     Assert.assertEquals(Duration.ofMillis(42000), settings.apiCallAttemptTimeout().get());
     Assert.assertEquals(Duration.ofMillis(13000), settings.apiCallTimeout().get());
-    Assert.assertEquals(Integer.valueOf(5), settings.retryPolicy().get().numRetries());
+    Assert.assertEquals(6, settings.retryStrategy().get().maxAttempts());
   }
 
   @Test


### PR DESCRIPTION
The RetryPolicy classes are deprecated. Update to use the newer RetryStrategy ([docs]).

[docs]: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/retry-strategy.html