### PR TITLE
spring 6.2.2 and spring-boot 3.4.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,8 @@ object Dependencies {
     val scala      = "2.12.19"
     val slf4j      = "2.0.17"
     val spectator  = "1.8.7"
-    val spring     = "6.2.3"
-    val springBoot = "3.4.3"
+    val spring     = "6.2.2"
+    val springBoot = "3.4.2"
   }
 
   import Versions._


### PR DESCRIPTION
Move back to older versions. Some internal apps are seeing deadlocks with 6.2.3. Maybe fixed in 6.2.4, but testing is still being done.