### PR TITLE
update to publish to central portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
         run: |
           git fetch --unshallow --tags
           cat /dev/null | project/sbt clean test publishSigned
-          cat /dev/null | project/sbt sonatypeBundleRelease
+          cat /dev/null | project/sbt sonaRelease

--- a/project/SonatypeSettings.scala
+++ b/project/SonatypeSettings.scala
@@ -1,7 +1,5 @@
 import sbt._
 import sbt.Keys._
-import xerial.sbt.Sonatype._
-import xerial.sbt.Sonatype.SonatypeKeys._
 
 object SonatypeSettings {
 
@@ -12,14 +10,36 @@ object SonatypeSettings {
   private lazy val user = get("USERNAME")
   private lazy val pass = get("PASSWORD")
 
-  lazy val settings: Seq[Def.Setting[_]] = sonatypeSettings ++ Seq(
-    sonatypeProfileName := "com.netflix",
-    sonatypeProjectHosting := Some(GitHubHosting("Netflix", "iep", "netflixoss@netflix.com")),
+  lazy val settings: Seq[Def.Setting[_]] = Seq(
+    organization := "com.netflix",
+    organizationName := "netflix",
+    organizationHomepage := Some(url("https://github.com/Netflix")),
+
+    scmInfo := Some(
+      ScmInfo(
+        url("https://github.com/Netflix/iep"),
+        "scm:git@github.com:Netflix/iep.git"
+      )
+    ),
+
+    developers := List(
+      Developer(
+        id = "netflixgithub",
+        name = "Netflix Open Source Development",
+        email = "netflixoss@netflix.com",
+        url = url("https://github.com/Netflix")
+      )
+    ),
 
     publishMavenStyle := true,
     licenses += ("APL2" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
-    credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", user, pass),
+    credentials += Credentials("Sonatype Central Portal", "central.sonatype.com", user, pass),
 
-    publishTo := sonatypePublishToBundle.value
+    publishTo := {
+      if (isSnapshot.value)
+        Some(Resolver.sonatypeCentralSnapshots)
+      else
+        localStaging.value
+    }
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.0
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
-addSbtPlugin("org.xerial.sbt"            % "sbt-sonatype"         % "3.11.0")
-addSbtPlugin("com.github.sbt"            % "sbt-pgp"              % "2.2.1")
+addSbtPlugin("com.github.sbt"            % "sbt-pgp"              % "2.3.1")
 addSbtPlugin("com.github.sbt"            % "sbt-release"          % "1.4.0")
 addSbtPlugin("pl.project13.scala"        % "sbt-jmh"              % "0.4.7")
 addSbtPlugin("com.github.sbt"            % "sbt-git"              % "2.0.1")


### PR DESCRIPTION
Sonatype is phasing out OSSRH so update the publishing to go to the new central portal.