### PR TITLE
update to jackson 3

### DIFF
--- a/iep-admin/src/main/java/com/netflix/iep/admin/ErrorMessage.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/ErrorMessage.java
@@ -15,9 +15,12 @@
  */
 package com.netflix.iep.admin;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 /**
  * Represents an error response that should be sent to the user.
  */
+@JsonPropertyOrder({"status", "message"})
 public class ErrorMessage {
 
   private final int status;

--- a/iep-admin/src/main/java/com/netflix/iep/admin/JsonEncoder.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/JsonEncoder.java
@@ -15,9 +15,11 @@
  */
 package com.netflix.iep.admin;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonEncoding;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -27,14 +29,14 @@ import java.io.OutputStream;
  */
 class JsonEncoder {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final JsonFactory FACTORY = new JsonFactory();
+  private static final JsonMapper MAPPER = new JsonMapper();
+  private static final JsonFactory FACTORY = JsonFactory.builder().build();
 
   @SuppressWarnings("unchecked")
   static void encode(Object obj, OutputStream out) throws IOException {
     if (obj instanceof Iterable<?>) {
       Iterable<Object> values = (Iterable<Object>) obj;
-      try (JsonGenerator gen = FACTORY.createGenerator(out)) {
+      try (JsonGenerator gen = FACTORY.createGenerator(ObjectWriteContext.empty(), out, JsonEncoding.UTF8)) {
         gen.writeStartArray();
         for (Object value : values) {
           MAPPER.writeValue(gen, value);

--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EddaLoader.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EddaLoader.java
@@ -15,8 +15,8 @@
  */
 package com.netflix.iep.servergroups;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
 import com.netflix.spectator.ipc.http.HttpClient;
 import com.netflix.spectator.ipc.http.HttpResponse;
 import org.slf4j.Logger;
@@ -91,7 +91,7 @@ public class EddaLoader implements Loader {
   }
 
   private List<Instance> decodeInstances(JsonParser jp) throws IOException {
-    if (jp.getCurrentToken() == JsonToken.VALUE_NULL) {
+    if (jp.currentToken() == JsonToken.VALUE_NULL) {
       return Collections.emptyList();
     }
     List<Instance> vs = new ArrayList<>();

--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EurekaLoader.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EurekaLoader.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.iep.servergroups;
 
-import com.fasterxml.jackson.core.JsonParser;
+import tools.jackson.core.JsonParser;
 import com.netflix.spectator.ipc.http.HttpClient;
 import com.netflix.spectator.ipc.http.HttpResponse;
 

--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/JsonUtils.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/JsonUtils.java
@@ -15,11 +15,12 @@
  */
 package com.netflix.iep.servergroups;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.JsonToken;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.TokenStreamLocation;
+import tools.jackson.core.json.JsonFactory;
 import com.netflix.spectator.ipc.http.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,23 +39,23 @@ final class JsonUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JsonUtils.class);
 
-  private static final JsonFactory FACTORY = new JsonFactory();
+  private static final JsonFactory FACTORY = JsonFactory.builder().build();
 
   private static boolean isEndOfArrayOrInput(JsonParser jp) {
-    JsonToken t = jp.getCurrentToken();
+    JsonToken t = jp.currentToken();
     return t == null || t == JsonToken.END_ARRAY;
   }
 
   private static boolean isEndOfObjectOrInput(JsonParser jp) {
-    JsonToken t = jp.getCurrentToken();
+    JsonToken t = jp.currentToken();
     return t == null || t == JsonToken.END_OBJECT;
   }
 
   /** Check that the current token for the parser is of the expected type. */
   private static void expect(JsonParser jp, JsonToken expected) throws IOException {
-    JsonToken actual = jp.getCurrentToken();
+    JsonToken actual = jp.currentToken();
     if (actual != expected) {
-      JsonLocation loc = jp.currentLocation();
+      TokenStreamLocation loc = jp.currentLocation();
       throw new IllegalArgumentException(
           "invalid input: expected " + expected + ", received " + actual
               + " (line " + loc.getLineNr() + ", column " + loc.getColumnNr() + ")");
@@ -63,7 +64,7 @@ final class JsonUtils {
 
   /** Create a list from the current array value. */
   static <T> List<T> toList(JsonParser jp, IOFunction<T> f) throws IOException {
-    if (jp.getCurrentToken() == JsonToken.VALUE_NULL) {
+    if (jp.currentToken() == JsonToken.VALUE_NULL) {
       return Collections.emptyList();
     }
     List<T> vs = new ArrayList<>();
@@ -78,7 +79,7 @@ final class JsonUtils {
     while (!isEndOfArrayOrInput(jp)) {
       f.apply(jp);
     }
-    if (jp.getCurrentToken() == JsonToken.END_ARRAY) {
+    if (jp.currentToken() == JsonToken.END_ARRAY) {
       jp.nextToken();
     }
   }
@@ -88,22 +89,22 @@ final class JsonUtils {
     expect(jp, JsonToken.START_OBJECT);
     jp.nextToken();
     while (!isEndOfObjectOrInput(jp)) {
-      expect(jp, JsonToken.FIELD_NAME);
+      expect(jp, JsonToken.PROPERTY_NAME);
       jp.nextToken();
       f.apply(jp.currentName(), jp);
     }
-    if (jp.getCurrentToken() == JsonToken.END_OBJECT) {
+    if (jp.currentToken() == JsonToken.END_OBJECT) {
       jp.nextToken();
     }
   }
 
   /** Extract a string value. */
   static String stringValue(JsonParser jp) throws IOException {
-    if (jp.getCurrentToken() == JsonToken.VALUE_NULL) {
+    if (jp.currentToken() == JsonToken.VALUE_NULL) {
       return null;
     }
     expect(jp, JsonToken.VALUE_STRING);
-    String v = jp.getText();
+    String v = jp.getString();
     jp.nextToken();
     return v;
   }
@@ -114,7 +115,7 @@ final class JsonUtils {
     int v = -1;
     try {
       v = jp.getIntValue();
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       LOGGER.warn("failed to parse value as integer", e);
     }
     jp.nextToken();
@@ -126,10 +127,10 @@ final class JsonUtils {
    * tokens and set the position to the token after the end of the array or object.
    */
   static void skipValue(JsonParser jp) throws IOException {
-    if (jp.getCurrentToken() == null) {
+    if (jp.currentToken() == null) {
       return;
     }
-    switch (jp.getCurrentToken()) {
+    switch (jp.currentToken()) {
       case START_ARRAY:
       case START_OBJECT:
         jp.skipChildren();
@@ -169,12 +170,12 @@ final class JsonUtils {
       // full decompressed payload.
       try (
           GZIPInputStream gzin = new GZIPInputStream(new ByteArrayInputStream(response.entity()));
-          JsonParser jp = FACTORY.createParser(gzin)
+          JsonParser jp = FACTORY.createParser(ObjectReadContext.empty(), gzin)
       ) {
         return function.apply(jp);
       }
     } else {
-      try (JsonParser jp = FACTORY.createParser(response.entity())) {
+      try (JsonParser jp = FACTORY.createParser(ObjectReadContext.empty(), response.entity())) {
         return function.apply(jp);
       }
     }

--- a/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/Context.java
+++ b/iep-spring-userservice/src/main/java/com/netflix/iep/userservice/Context.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.iep.userservice;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.ipc.http.HttpClient;
 import com.netflix.spectator.ipc.http.HttpRequestBuilder;
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 /** Common settings used across all services. */
 public final class Context implements AutoCloseable {
 
-  private final ObjectMapper mapper = new ObjectMapper();
+  private final JsonMapper mapper = new JsonMapper();
 
   private final Registry registry;
 
@@ -82,7 +82,7 @@ public final class Context implements AutoCloseable {
     executor.shutdown();
   }
 
-  ObjectMapper objectMapper() {
+  JsonMapper objectMapper() {
     return mapper;
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object Versions {
     val assertj    = "3.27.7"
     val aws2       = "2.41.22"
-    val jackson    = "2.21.0"
+    val jackson    = "3.0.3"
     val scala      = "2.12.20"
     val slf4j      = "2.0.17"
     val spectator  = "1.9.4"
@@ -23,20 +23,16 @@ object Dependencies {
   val aws2UrlClient      = "software.amazon.awssdk" % "url-connection-client" % aws2
   val caffeine           = "com.github.ben-manes.caffeine" % "caffeine" % "3.2.3"
   val equalsVerifier     = "nl.jqno.equalsverifier" % "equalsverifier" % "4.3.1"
-  val jacksonCore        = "com.fasterxml.jackson.core" % "jackson-core" % jackson
-  val jacksonMapper      = "com.fasterxml.jackson.core" % "jackson-databind" % jackson
+  val jacksonCore        = "tools.jackson.core" % "jackson-core" % jackson
+  val jacksonMapper      = "tools.jackson.core" % "jackson-databind" % jackson
   val jakartaAnno        = "jakarta.annotation" % "jakarta.annotation-api" % "3.0.0"
   val jakartaInject      = "jakarta.inject" % "jakarta.inject-api" % "2.0.1"
-  val jodaTime           = "joda-time" % "joda-time" % "2.10.10"
   val jedis              = "redis.clients" % "jedis" % "7.2.1"
-  val junit              = "junit" % "junit" % "4.12"
   val junitInterface     = "com.novocode" % "junit-interface" % "0.11"
-  val jzlib              = "com.jcraft" % "jzlib" % "1.1.3"
   val mockitoCore        = "org.mockito" % "mockito-core" % "5.21.0"
   val slf4jApi           = "org.slf4j" % "slf4j-api" % slf4j
   val spectatorApi       = "com.netflix.spectator" % "spectator-api" % spectator
   val spectatorAtlas     = "com.netflix.spectator" % "spectator-reg-atlas" % spectator
-  val spectatorAws       = "com.netflix.spectator" % "spectator-ext-aws" % spectator
   val spectatorGc        = "com.netflix.spectator" % "spectator-ext-gc" % spectator
   val spectatorIpc       = "com.netflix.spectator" % "spectator-ext-ipc" % spectator
   val spectatorJvm       = "com.netflix.spectator" % "spectator-ext-jvm" % spectator


### PR DESCRIPTION
Update Jackson from 2.21.0 to 3.0.3 which changes the Maven group IDs from com.fasterxml.jackson.core to tools.jackson.core and the Java package names from com.fasterxml.jackson to tools.jackson. In Jackson 3, ObjectMapper is abstract so usages are updated to use JsonMapper, JsonFactory construction uses the builder pattern, deprecated methods like getCurrentToken and getText are replaced with currentToken and getString, JsonToken.FIELD_NAME is renamed to PROPERTY_NAME, and JsonLocation is renamed to TokenStreamLocation. ErrorMessage is annotated with @JsonPropertyOrder to preserve serialization order. Unused dependencies are also cleaned up from Dependencies.scala.