### PR TITLE
use registry close for lifecycle with spectator 1.10.1

### DIFF
--- a/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
+++ b/iep-spring-atlas/src/main/java/com/netflix/iep/atlas/AtlasRegistryService.java
@@ -58,7 +58,6 @@ class AtlasRegistryService extends AbstractService {
   private final Config config;
 
   private AtlasRegistry registry;
-  private GcLogger gcLogger;
 
   AtlasRegistryService(Clock clock, Config config) {
     this.clock = (clock == null) ? Clock.SYSTEM : clock;
@@ -87,9 +86,8 @@ class AtlasRegistryService extends AbstractService {
     Spectator.globalRegistry().add(registry);
 
     // Enable GC logger
-    gcLogger = new GcLogger();
     if (cfg.getBoolean("atlas.collection.gc")) {
-      gcLogger.start(null);
+      GcLogger.monitor(registry);
     }
 
     // Enable JVM data collection
@@ -99,8 +97,7 @@ class AtlasRegistryService extends AbstractService {
   }
 
   @Override protected void stopImpl() throws Exception {
-    gcLogger.stop();
-    registry.stop();
+    registry.close();
   }
 
   private static class TypesafeAtlasConfig implements AtlasConfig {

--- a/iep-spring-spectatord/src/main/java/com/netflix/iep/spectatord/SidecarRegistryService.java
+++ b/iep-spring-spectatord/src/main/java/com/netflix/iep/spectatord/SidecarRegistryService.java
@@ -50,7 +50,6 @@ class SidecarRegistryService extends AbstractService {
   private final Config config;
 
   private SidecarRegistry registry;
-  private GcLogger gcLogger;
 
   SidecarRegistryService(Config config) {
     this.config = (config == null) ? defaultConfig() : config;
@@ -77,9 +76,8 @@ class SidecarRegistryService extends AbstractService {
     Spectator.globalRegistry().add(registry);
 
     // Enable GC logger
-    gcLogger = new GcLogger();
     if (cfg.getBoolean("sidecar.collection.gc")) {
-      gcLogger.start(null);
+      GcLogger.monitor(registry);
     }
 
     // Enable JVM data collection
@@ -89,7 +87,7 @@ class SidecarRegistryService extends AbstractService {
   }
 
   @Override protected void stopImpl() throws Exception {
-    gcLogger.stop();
+    registry.close();
   }
 
   private static class TypesafeConfig implements SidecarConfig {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val jackson    = "3.1.4"
     val scala      = "2.12.20"
     val slf4j      = "2.0.18"
-    val spectator  = "1.9.7"
+    val spectator  = "1.10.1"
     val spring     = "7.0.7"
     val springBoot = "4.0.6"
   }


### PR DESCRIPTION
Spectator 1.10.0 ties the GC logger lifecycle to the registry via GcLogger.monitor(registry), and AtlasRegistry/SidecarRegistry now flush and release resources (including PolledMeter background tasks) on close(). Update the registry services to use the new APIs instead of managing the GcLogger and registry stop by hand. Bump to 1.10.1 to pick up the IDE warning fixes.