### PR TITLE
reject path traversal in StaticResourceHandler

### DIFF
--- a/iep-admin/src/main/java/com/netflix/iep/admin/StaticResourceHandler.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/StaticResourceHandler.java
@@ -72,9 +72,19 @@ class StaticResourceHandler implements HttpHandler {
       }
     }
 
+    String resource = path.substring(1);
+    if (!isSafeResource(resource)) {
+      // Reject path traversal attempts. The JDK http server does not normalize the
+      // request path before dispatch, so a request such as `/static/../application.conf`
+      // (or the percent-encoded `%2e%2e` form, which getPath decodes) would otherwise be
+      // resolved by the class loader to a sibling classpath resource and disclosed.
+      LOGGER.debug("rejecting unsafe resource path {}", resource);
+      exchange.sendResponseHeaders(404, -1);
+      return;
+    }
+
     exchange.getResponseHeaders().add("Content-Type", getContentType(path));
 
-    String resource = path.substring(1);
     LOGGER.debug("loading resource {}", resource);
     try (InputStream in = classLoader.getResourceAsStream(resource)) {
       if (in == null) {
@@ -96,6 +106,25 @@ class StaticResourceHandler implements HttpHandler {
       e.printStackTrace();
       LOGGER.debug("failed to serve resource " + resource, e);
     }
+  }
+
+  /**
+   * Check that a class loader resource path cannot traverse outside the intended resource
+   * root. The path has already been URL-decoded by the http server, so `..` and its encoded
+   * forms both appear here as literal `..` path segments. Backslashes and null bytes are
+   * rejected outright as they have no place in a legitimate resource path and can be used to
+   * confuse path handling.
+   */
+  static boolean isSafeResource(String resource) {
+    if (resource.indexOf('\0') >= 0 || resource.indexOf('\\') >= 0) {
+      return false;
+    }
+    for (String segment : resource.split("/")) {
+      if (segment.equals("..") || segment.equals(".")) {
+        return false;
+      }
+    }
+    return true;
   }
 
   String getExtension(String name) {

--- a/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/AdminServerTest.java
@@ -280,6 +280,15 @@ public class AdminServerTest {
   }
 
   @Test
+  public void staticContentPathTraversal() throws Exception {
+    // Encoded `..` so the client does not normalize it away before sending. Without the
+    // traversal guard the class loader would resolve this back to `static/test.txt` and
+    // return 200 with its contents; with the guard it must be rejected.
+    Response res = httpGet("/static/%2e%2e/static/test.txt");
+    Assert.assertEquals(404, res.status);
+  }
+
+  @Test
   public void cors() throws Exception {
     // Pre-flight
     Response res = httpOptions("/test", Collections.singletonMap("Origin", "foo"));

--- a/iep-admin/src/test/java/com/netflix/iep/admin/StaticResourceHandlerTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/StaticResourceHandlerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.admin;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class StaticResourceHandlerTest {
+
+  @Test
+  public void safePaths() {
+    Assert.assertTrue(StaticResourceHandler.isSafeResource("static/index.html"));
+    Assert.assertTrue(StaticResourceHandler.isSafeResource("static/css/app.css"));
+    Assert.assertTrue(StaticResourceHandler.isSafeResource("static/test.txt"));
+    // A dot within a segment is fine, only a whole `.`/`..` segment is a traversal.
+    Assert.assertTrue(StaticResourceHandler.isSafeResource("static/..foo/a.b.c.js"));
+  }
+
+  @Test
+  public void parentTraversalRejected() {
+    Assert.assertFalse(StaticResourceHandler.isSafeResource("static/../application.conf"));
+    Assert.assertFalse(StaticResourceHandler.isSafeResource("static/../../etc/passwd"));
+    Assert.assertFalse(StaticResourceHandler.isSafeResource(".."));
+    Assert.assertFalse(StaticResourceHandler.isSafeResource("../static/index.html"));
+    Assert.assertFalse(StaticResourceHandler.isSafeResource("static/../"));
+  }
+
+  @Test
+  public void currentDirSegmentRejected() {
+    Assert.assertFalse(StaticResourceHandler.isSafeResource("./static/index.html"));
+    Assert.assertFalse(StaticResourceHandler.isSafeResource("static/./index.html"));
+  }
+
+  @Test
+  public void backslashRejected() {
+    Assert.assertFalse(StaticResourceHandler.isSafeResource("static\\..\\application.conf"));
+  }
+
+  @Test
+  public void nullByteRejected() {
+    Assert.assertFalse(StaticResourceHandler.isSafeResource("static/index.html\u0000.png"));
+  }
+}


### PR DESCRIPTION
StaticResourceHandler served any request path straight to ClassLoader.getResourceAsStream after only checking the single-page prefixes. The JDK http server does not normalize the request path before dispatch, so a request such as `/static/../application.conf` (or the percent-encoded `%2e%2e` form, which getPath decodes) resolved to a sibling classpath resource and streamed its contents back with a 200 response. Any config/resource on the application classpath (reference.conf, logback.xml, compiled classes, BOOT-INF/classes/* in a fat jar) was readable through the unauthenticated /static and /ui contexts.

Add an isSafeResource guard that rejects any `.`/`..` path segment plus backslashes and null bytes, returning 404 before touching the class loader. Add an end-to-end traversal test (verified to return 200 without the guard) and unit tests for the guard.