### PR TITLE
use spectator PatternMatcher for admin regex filters

### DIFF
--- a/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/SpectatorEndpoint.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/SpectatorEndpoint.java
@@ -23,6 +23,7 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Tag;
 import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.impl.PatternMatcher;
 import com.netflix.spectator.impl.Preconditions;
 
 import java.util.ArrayDeque;
@@ -33,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.regex.Pattern;
 
 /**
  * List measurements via Spectator. The path can be an Atlas query expression
@@ -380,7 +380,7 @@ public class SpectatorEndpoint implements HttpEndpoint {
           case ":reic":
             v = (String) stack.pop();
             k = (String) stack.pop();
-            stack.push(new RegexQuery(k, v, Pattern.CASE_INSENSITIVE, ":reic"));
+            stack.push(new RegexQuery(k, v, true, ":reic"));
             break;
           default:
             if (token.startsWith(":")) {
@@ -597,23 +597,24 @@ public class SpectatorEndpoint implements HttpEndpoint {
   private static class RegexQuery implements Query {
     private final String k;
     private final String v;
-    private final Pattern pattern;
+    private final PatternMatcher pattern;
     private final String name;
 
     RegexQuery(String k, String v) {
-      this(k, v, 0, ":re");
+      this(k, v, false, ":re");
     }
 
-    RegexQuery(String k, String v, int flags, String name) {
+    RegexQuery(String k, String v, boolean ignoreCase, String name) {
       this.k = Preconditions.checkNotNull(k, "k");
       this.v = Preconditions.checkNotNull(v, "v");
-      this.pattern = Pattern.compile("^" + v, flags);
+      PatternMatcher m = PatternMatcher.compile("^" + v);
+      this.pattern = ignoreCase ? m.ignoreCase() : m;
       this.name = Preconditions.checkNotNull(name, "name");
     }
 
     @Override public boolean matches(Map<String, String> tags) {
       String s = tags.get(k);
-      return s != null && pattern.matcher(s).find();
+      return s != null && pattern.matches(s);
     }
 
     @Override public String toString() {

--- a/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/ThreadsEndpoint.java
+++ b/iep-admin/src/main/java/com/netflix/iep/admin/endpoints/ThreadsEndpoint.java
@@ -16,11 +16,11 @@
 package com.netflix.iep.admin.endpoints;
 
 import com.netflix.iep.admin.HttpEndpoint;
+import com.netflix.spectator.impl.PatternMatcher;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -47,9 +47,9 @@ public class ThreadsEndpoint implements HttpEndpoint {
   }
 
   @Override public Object get(String path) {
-    Pattern p = Pattern.compile(path);
+    PatternMatcher p = PatternMatcher.compile(path);
     return threads().stream()
-        .filter(t -> p.matcher(t.getName()).find())
+        .filter(t -> p.matches(t.getName()))
         .collect(Collectors.toList());
   }
 

--- a/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SpectatorEndpointTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/SpectatorEndpointTest.java
@@ -243,4 +243,17 @@ public class SpectatorEndpointTest {
     Assert.assertEquals(100.0, datapoints.get(0).getValue(), 1e-12);
   }
 
+  @Test(timeout = 5000)
+  public void getRegexNoCatastrophicBacktracking() {
+    // A catastrophic-backtracking pattern such as "^(a+)+$" evaluated against a long run
+    // of matching characters followed by a non-matching one would take exponential time on
+    // the java.util.regex backtracking engine, hanging the admin server. PatternMatcher
+    // evaluates it in linear time, so this completes well within the timeout.
+    Registry r = new DefaultRegistry();
+    r.counter("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!").increment();
+    SpectatorEndpoint ep = new SpectatorEndpoint(r);
+    List<Object> datapoints = toList(ep.get("name,(a+)+$,:re"));
+    Assert.assertTrue(datapoints.isEmpty());
+  }
+
 }

--- a/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/ThreadsEndpointTest.java
+++ b/iep-admin/src/test/java/com/netflix/iep/admin/endpoints/ThreadsEndpointTest.java
@@ -23,7 +23,6 @@ import org.junit.runners.JUnit4;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.PatternSyntaxException;
 
 
 @RunWith(JUnit4.class)
@@ -71,7 +70,7 @@ public class ThreadsEndpointTest {
     Assert.assertEquals(0, infos.size());
   }
 
-  @Test(expected = PatternSyntaxException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void getWithPathBadRegex() {
     endpoint.get("(");
   }

--- a/iep-spring-admin/src/main/java/com/netflix/iep/admin/spring/SpringBeansEndpoint.java
+++ b/iep-spring-admin/src/main/java/com/netflix/iep/admin/spring/SpringBeansEndpoint.java
@@ -16,6 +16,7 @@
 package com.netflix.iep.admin.spring;
 
 import com.netflix.iep.admin.HttpEndpoint;
+import com.netflix.spectator.impl.PatternMatcher;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
@@ -23,7 +24,6 @@ import org.springframework.context.support.GenericApplicationContext;
 
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -42,11 +42,11 @@ public class SpringBeansEndpoint implements HttpEndpoint {
   }
 
   @Override public Object get(String path) {
-    Pattern p = Pattern.compile(path);
+    PatternMatcher p = PatternMatcher.compile(path);
     return getMappings()
         .entrySet()
         .stream()
-        .filter(e -> p.matcher(e.getKey()).find() || matches(p, e.getValue()))
+        .filter(e -> p.matches(e.getKey()) || matches(p, e.getValue()))
         .collect(Collectors.toMap(
             Map.Entry<String, Map<String, Object>>::getKey,
             Map.Entry<String, Map<String, Object>>::getValue,
@@ -55,13 +55,13 @@ public class SpringBeansEndpoint implements HttpEndpoint {
         ));
   }
 
-  private boolean matches(Pattern p, Map<String, Object> value) {
+  private boolean matches(PatternMatcher p, Map<String, Object> value) {
     return value.values().stream().anyMatch(obj -> {
       if (obj instanceof String) {
-        return p.matcher((String) obj).find();
+        return p.matches((String) obj);
       } else if (obj instanceof String[]) {
         for (String s : (String[]) obj) {
-          if (p.matcher(s).find())
+          if (p.matches(s))
             return true;
         }
         return false;


### PR DESCRIPTION
The /threads, /spring-beans, and /spectator (:re/:reic) endpoints compiled an untrusted request path/operand as a java.util.regex pattern and evaluated it with find(). java.util.regex uses a backtracking engine, so a crafted pattern (e.g. `(a+)+$`) could cause catastrophic backtracking and pin the single-threaded admin server (ReDoS).

Switch these filters to spectator's PatternMatcher, a linear-time (backtracking-free) matcher already used for Atlas :re query handling. Behavior is preserved: PatternMatcher.matches() uses find semantics (unanchored) and honors the leading `^` anchor and ignore-case that the RegexQuery relied on. A malformed pattern now raises IllegalArgumentException instead of the PatternSyntaxException subclass, which RequestHandler already maps to a 400.

Add a regression test that evaluates a catastrophic-backtracking pattern against a long non-matching meter name under a timeout.