### PR TITLE
tolerate unknown Eureka instance status

### DIFF
--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EurekaLoader.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EurekaLoader.java
@@ -18,6 +18,8 @@ package com.netflix.iep.servergroups;
 import tools.jackson.core.JsonParser;
 import com.netflix.spectator.ipc.http.HttpClient;
 import com.netflix.spectator.ipc.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -39,10 +41,30 @@ import java.util.regex.Pattern;
  */
 public class EurekaLoader implements Loader {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(EurekaLoader.class);
+
   // Some environments like Titus can result in arbitrary values for the
   // instance type in the metadata. This pattern is used to check for reasonable
   // values.
   private static final Pattern VM_TYPE_PATTERN = Pattern.compile("^[a-zA-Z0-9]+\\.[a-zA-Z0-9]+$");
+
+  /**
+   * Map the status string reported by Eureka to a {@link Instance.Status}. Unrecognized or
+   * missing values are mapped to {@link Instance.Status#UNKNOWN} rather than allowing the
+   * {@code valueOf} to throw, which would otherwise abort decoding of the entire response and
+   * discard every server group. This can happen if the set of Eureka status values is extended
+   * or skews from the values known here.
+   */
+  private static Instance.Status decodeStatus(String value) {
+    if (value != null) {
+      try {
+        return Instance.Status.valueOf(value);
+      } catch (IllegalArgumentException e) {
+        LOGGER.warn("unknown Eureka instance status '{}', treating as UNKNOWN", value);
+      }
+    }
+    return Instance.Status.UNKNOWN;
+  }
 
   private final HttpClient client;
   private final URI uri;
@@ -132,7 +154,7 @@ public class EurekaLoader implements Loader {
           info.node = JsonUtils.stringValue(p);
           break;
         case "status":
-          info.builder.status(Instance.Status.valueOf(JsonUtils.stringValue(p)));
+          info.builder.status(decodeStatus(JsonUtils.stringValue(p)));
           break;
         case "dataCenterInfo":
           decodeDataCenterInfo(info, p);

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EurekaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EurekaLoaderTest.java
@@ -166,6 +166,28 @@ public class EurekaLoaderTest {
     Assert.assertEquals(expected, actual);
   }
 
+  @Test
+  public void unknownStatusMappedToUnknown() throws Exception {
+    // An unrecognized status value must not abort decoding of the response. The instance
+    // should still be loaded, with the status mapped to UNKNOWN.
+    List<ServerGroup> expected = new ArrayList<>();
+    expected.add(ServerGroup.builder()
+        .platform("ec2")
+        .group("app-main-v001")
+        .addInstance(Instance.builder()
+            .node("i-1234567890")
+            .privateIpAddress("10.20.30.40")
+            .vpcId("vpc-54321")
+            .ami("ami-0987654321")
+            .vmtype("m5.large")
+            .zone("us-east-1d")
+            .status(Instance.Status.UNKNOWN)
+            .build())
+        .build());
+    List<ServerGroup> actual = get("eureka-unknown-status.json");
+    Assert.assertEquals(expected, actual);
+  }
+
   @Test(expected = IOException.class)
   public void failedRequest() throws Exception {
     HttpClient client = TestHttpClient.empty(400);

--- a/iep-servergroups/src/test/resources/eureka-unknown-status.json
+++ b/iep-servergroups/src/test/resources/eureka-unknown-status.json
@@ -1,0 +1,66 @@
+{
+  "applications": {
+    "application": [
+      {
+        "name": "APP",
+        "instance": [
+          {
+            "instanceId": "i-1234567890",
+            "app": "APP",
+            "appGroupName": "UNKNOWN",
+            "ipAddr": "10.20.30.40",
+            "sid": "na",
+            "homePageUrl": "http://10.20.30.40:7101/",
+            "statusPageUrl": "http://10.20.30.40:7101/Status",
+            "healthCheckUrl": "http://10.20.30.40:7101/healthcheck",
+            "vipAddress": "app-main:7001",
+            "countryId": 1,
+            "dataCenterInfo": {
+              "@class": "com.netflix.appinfo.AmazonInfo",
+              "name": "Amazon",
+              "metadata": {
+                "mac": "0a:0b:0c:0d:0e:0f",
+                "local-hostname": "ip-10-20-30-40.ec2.internal",
+                "instance-id": "i-1234567890",
+                "availability-zone": "us-east-1d",
+                "instance-type": "m5.large",
+                "ami-id": "ami-0987654321",
+                "accountId": "12345",
+                "public-hostname": "10.20.30.40",
+                "vpc-id": "vpc-54321",
+                "local-ipv4": "10.20.30.40"
+              }
+            },
+            "hostName": "10.20.30.40",
+            "status": "SOME_NEW_STATUS",
+            "overriddenStatus": "UNKNOWN",
+            "leaseInfo": {
+              "renewalIntervalInSecs": 30,
+              "durationInSecs": 90,
+              "registrationTimestamp": 1551379716423,
+              "lastRenewalTimestamp": 1551934330011,
+              "evictionTimestamp": 0,
+              "serviceUpTimestamp": 1551379716423
+            },
+            "isCoordinatingDiscoveryServer": false,
+            "lastUpdatedTimestamp": 1551379716423,
+            "lastDirtyTimestamp": 1551379715718,
+            "actionType": "ADDED",
+            "asgName": "app-main-v001",
+            "port": {
+              "$": 7101,
+              "@enabled": "true"
+            },
+            "securePort": {
+              "$": 7102,
+              "@enabled": "false"
+            },
+            "metadata": {
+              "@class": "java.util.Collections$EmptyMap"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
decodeInstance parsed the Eureka status field with Instance.Status.valueOf, which throws IllegalArgumentException for any value not in the enum. Because that throw happens mid-object (while decoding one instance's fields), a single unrecognized status aborts decoding of the entire /v2/apps response and discards every server group. This can occur from Eureka status-enum skew or a new status value added server-side. Unlike EddaLoader, whose per-instance guard catches at build() time after the object is fully consumed, catching here would leave the JsonParser misaligned for subsequent instances.

Map unrecognized or null status values to the existing Status.UNKNOWN ("registered, but the status is not known") instead, keeping the instance in the server group and logging a warning. Add a test with an unknown status value asserting the instance is still loaded as UNKNOWN.