### PR TITLE
add launch time to server group instances

### DIFF
--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EddaLoader.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/EddaLoader.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -80,6 +81,16 @@ public class EddaLoader implements Loader {
           break;
         case "zone":
           builder.zone(JsonUtils.stringValue(jp));
+          break;
+        case "launchTime":
+          // Only set when a real value is present. A JSON null must still be consumed here;
+          // routing it through longValue would fail the VALUE_NUMBER_INT check and abort the
+          // parse mid-object, stranding the parser and wedging the enclosing decode loops.
+          if (jp.currentToken() == JsonToken.VALUE_NULL) {
+            jp.nextToken();
+          } else {
+            builder.launchTime(Instant.ofEpochMilli(JsonUtils.longValue(jp)));
+          }
           break;
         default:
           // Ignore unknown fields

--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/Instance.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/Instance.java
@@ -17,6 +17,7 @@ package com.netflix.iep.servergroups;
 
 import com.netflix.spectator.impl.Preconditions;
 
+import java.time.Instant;
 import java.util.Objects;
 
 /**
@@ -35,6 +36,8 @@ public final class Instance {
   private final String vmtype;
   private final String zone;
 
+  private final Instant launchTime;
+
   private final Status status;
 
   private Instance(Builder builder) {
@@ -46,6 +49,7 @@ public final class Instance {
     ami = builder.ami;
     vmtype = builder.vmtype;
     zone = builder.zone;
+    launchTime = builder.launchTime;
     status = builder.status;
   }
 
@@ -84,12 +88,24 @@ public final class Instance {
     return zone;
   }
 
+  /**
+   * Return the time the instance was launched, or {@code null} if not known. This is only
+   * populated by sources that expose it (e.g. Edda); discovery data alone does not include it.
+   */
+  public Instant getLaunchTime() {
+    return launchTime;
+  }
+
   /** Return the status in Eureka for the instance. */
   public Status getStatus() {
     return status;
   }
 
   private String orElse(String v1, String v2) {
+    return v1 == null ? v2 : v1;
+  }
+
+  private Instant orElse(Instant v1, Instant v2) {
     return v1 == null ? v2 : v1;
   }
 
@@ -110,6 +126,7 @@ public final class Instance {
         .ami(orElse(ami, other.ami))
         .vmtype(orElse(vmtype, other.vmtype))
         .zone(orElse(zone, other.zone))
+        .launchTime(orElse(launchTime, other.launchTime))
         .status(status.ordinal() > other.status.ordinal() ? status : other.status)
         .build();
   }
@@ -130,11 +147,13 @@ public final class Instance {
         Objects.equals(ami, instance.ami) &&
         Objects.equals(vmtype, instance.vmtype) &&
         Objects.equals(zone, instance.zone) &&
+        Objects.equals(launchTime, instance.launchTime) &&
         status == instance.status;
   }
 
   @Override public int hashCode() {
-    return Objects.hash(node, privateIpAddress, ipv6Address, vpcId, subnetId, ami, vmtype, zone, status);
+    return Objects.hash(
+        node, privateIpAddress, ipv6Address, vpcId, subnetId, ami, vmtype, zone, launchTime, status);
   }
 
   @Override public String toString() {
@@ -147,6 +166,7 @@ public final class Instance {
         + "ami=" + ami + ", "
         + "vmtype=" + vmtype + ", "
         + "zone=" + zone + ", "
+        + "launchTime=" + launchTime + ", "
         + "status=" + status.name()
         + ")";
   }
@@ -166,6 +186,7 @@ public final class Instance {
     private String ami;
     private String vmtype;
     private String zone;
+    private Instant launchTime;
     private Status status;
 
     private Builder() {
@@ -216,6 +237,12 @@ public final class Instance {
     /** Set the availability zone. */
     public Builder zone(String value) {
       zone = value;
+      return this;
+    }
+
+    /** Set the launch time. May be left unset for sources that do not expose it. */
+    public Builder launchTime(Instant value) {
+      launchTime = value;
       return this;
     }
 

--- a/iep-servergroups/src/main/java/com/netflix/iep/servergroups/JsonUtils.java
+++ b/iep-servergroups/src/main/java/com/netflix/iep/servergroups/JsonUtils.java
@@ -122,6 +122,19 @@ final class JsonUtils {
     return v;
   }
 
+  /** Extract a long value. */
+  static long longValue(JsonParser jp) throws IOException {
+    expect(jp, JsonToken.VALUE_NUMBER_INT);
+    long v = -1L;
+    try {
+      v = jp.getLongValue();
+    } catch (JacksonException e) {
+      LOGGER.warn("failed to parse value as long", e);
+    }
+    jp.nextToken();
+    return v;
+  }
+
   /**
    * Skip the current JSON value. For arrays and objects it will skip over all of the
    * tokens and set the position to the token after the end of the array or object.

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/EddaLoaderTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -48,6 +49,7 @@ public class EddaLoaderTest {
             .ami("ami-0987654321")
             .vmtype("m5.large")
             .zone("us-east-1d")
+            .launchTime(Instant.ofEpochMilli(1544328558000L))
             .status(Instance.Status.NOT_REGISTERED)
             .build())
         .build();
@@ -79,6 +81,7 @@ public class EddaLoaderTest {
             .ami("ami-0987654321")
             .vmtype("m5.large")
             .zone("us-east-1d")
+            .launchTime(Instant.ofEpochMilli(1544328558000L))
             .status(Instance.Status.NOT_REGISTERED)
             .build())
         .build());
@@ -114,6 +117,7 @@ public class EddaLoaderTest {
             .ami("ami-0987654321")
             .vmtype("m5.large")
             .zone("us-east-1d")
+            .launchTime(Instant.ofEpochMilli(1544328558000L))
             .status(Instance.Status.NOT_REGISTERED)
             .build())
         .build());
@@ -133,6 +137,18 @@ public class EddaLoaderTest {
         .build());
     List<ServerGroup> actual = get("edda-no-instances.json");
     Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void nullLaunchTime() throws Exception {
+    // A JSON null for launchTime must be consumed without aborting the parse. The launchTime is
+    // left unset and the remaining fields (privateIpAddress, etc.) still parse.
+    List<ServerGroup> expected = new ArrayList<>();
+    expected.add(defaultEc2Group());
+    List<ServerGroup> actual = get("edda-null-launch-time.json");
+    Assert.assertNull(actual.get(0).getInstances().get(0).getLaunchTime());
+    Assert.assertEquals(expected.get(0).getInstances().get(0).getNode(),
+        actual.get(0).getInstances().get(0).getNode());
   }
 
   @Test

--- a/iep-servergroups/src/test/java/com/netflix/iep/servergroups/InstanceTest.java
+++ b/iep-servergroups/src/test/java/com/netflix/iep/servergroups/InstanceTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.time.Instant;
+
 @RunWith(JUnit4.class)
 public class InstanceTest {
 
@@ -100,6 +102,40 @@ public class InstanceTest {
   @Test
   public void zone() {
     Assert.assertEquals("us-east-1e", defaultInstance().getZone());
+  }
+
+  @Test
+  public void launchTimeDefaultsToNull() {
+    Assert.assertNull(defaultInstance().getLaunchTime());
+  }
+
+  @Test
+  public void launchTime() {
+    Instant t = Instant.ofEpochMilli(1544328558000L);
+    Instance instance = Instance.builder()
+        .node("i-12345")
+        .privateIpAddress("1.2.3.4")
+        .launchTime(t)
+        .status(Instance.Status.UP)
+        .build();
+    Assert.assertEquals(t, instance.getLaunchTime());
+  }
+
+  @Test
+  public void mergeFillsInLaunchTimeFromOther() {
+    Instant t = Instant.ofEpochMilli(1544328558000L);
+    Instance i1 = Instance.builder()
+        .node("i-12345")
+        .privateIpAddress("1.2.3.4")
+        .status(Instance.Status.NOT_REGISTERED)
+        .build();
+    Instance i2 = Instance.builder()
+        .node("i-12345")
+        .privateIpAddress("1.2.3.4")
+        .launchTime(t)
+        .status(Instance.Status.NOT_REGISTERED)
+        .build();
+    Assert.assertEquals(t, i1.merge(i2).getLaunchTime());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/iep-servergroups/src/test/resources/edda-null-launch-time.json
+++ b/iep-servergroups/src/test/resources/edda-null-launch-time.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ec2.app-main-dev-v001",
+    "platform": "ec2",
+    "app": "app",
+    "cluster": "app-main-dev",
+    "group": "app-main-dev-v001",
+    "stack": "main",
+    "detail": "dev",
+    "minSize": 1,
+    "maxSize": 3,
+    "desiredSize": 2,
+    "instances": [
+      {
+        "node": "i-1234567890",
+        "launchTime": null,
+        "privateIpAddress": "10.20.30.40",
+        "vpcId": "vpc-54321",
+        "subnetId": "subnet-54321",
+        "ami": "ami-0987654321",
+        "vmtype": "m5.large",
+        "zone": "us-east-1d"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Edda's serverGroups response includes a per-instance launchTime that was being dropped as an unknown field. Parse it into a new nullable Instant on Instance so consumers can reason about instance age (e.g. grace periods for nodes that are still starting up).

- add Instance.launchTime (builder, getter, merge, equals/hashCode)
- parse launchTime in EddaLoader; only Edda exposes it, so it stays null for discovery-only data
- add JsonUtils.longValue for the epoch-millis value

A JSON null for launchTime is consumed explicitly in EddaLoader rather than routed through longValue: longValue's VALUE_NUMBER_INT check would throw mid-object, stranding the parser and wedging the decode loops.