### PR TITLE
launcher: ignore empty classpath entries

### DIFF
--- a/iep-launcher/src/main/java/com/netflix/iep/launcher/JarBuilder.java
+++ b/iep-launcher/src/main/java/com/netflix/iep/launcher/JarBuilder.java
@@ -167,9 +167,23 @@ public class JarBuilder {
       System.exit(1);
     }
 
-    File[] jars = new File[args.length - 2];
-    for (int i = 0; i < jars.length; ++i) {
-      jars[i] = new File(args[i + 2]);
+    List<File> jars = new ArrayList<>();
+    for (int i = 2; i < args.length; ++i) {
+      // Skip empty/blank classpath elements. These can come from a leading, trailing,
+      // or repeated separator when a classpath string is split into arguments and are
+      // never valid jars; without this an empty path fails with a confusing
+      // FileNotFoundException. The File is created from the original argument so a path
+      // with significant surrounding whitespace is preserved.
+      if (!args[i].trim().isEmpty()) {
+        jars.add(new File(args[i]));
+      }
+    }
+
+    // Fail fast if the classpath was entirely empty rather than silently producing a
+    // jar with no dependencies (which would only fail later at runtime).
+    if (jars.isEmpty()) {
+      System.err.println("Error: no jars provided in classpath arguments");
+      System.exit(1);
     }
 
     new JarBuilder()

--- a/iep-launcher/src/test/java/com/netflix/iep/launcher/JarBuilderTest.java
+++ b/iep-launcher/src/test/java/com/netflix/iep/launcher/JarBuilderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.launcher;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+@RunWith(JUnit4.class)
+public class JarBuilderTest {
+
+  @Rule
+  public final TemporaryFolder folder = new TemporaryFolder();
+
+  private Set<String> entryNames(File jar) throws Exception {
+    Set<String> names = new HashSet<>();
+    try (ZipFile zf = new ZipFile(jar)) {
+      Enumeration<? extends ZipEntry> entries = zf.entries();
+      while (entries.hasMoreElements()) {
+        names.add(entries.nextElement().getName());
+      }
+    }
+    return names;
+  }
+
+  private File dep(String name) throws Exception {
+    File dep = new File(folder.getRoot(), name);
+    Files.write(dep.toPath(), "dep".getBytes(StandardCharsets.UTF_8));
+    return dep;
+  }
+
+  @Test
+  public void emptyClasspathElementsAreIgnored() throws Exception {
+    File dep = dep("dep.jar");
+    File out = new File(folder.getRoot(), "out.jar");
+
+    // Empty entries (from a leading/trailing/repeated separator when a classpath
+    // string is split) must be skipped rather than failing with FileNotFoundException.
+    JarBuilder.main(new String[] {
+        out.getAbsolutePath(), "com.example.Main", "", dep.getAbsolutePath(), ""
+    });
+
+    Assert.assertTrue("output jar should be created", out.exists());
+    Set<String> names = entryNames(out);
+    Assert.assertTrue("real dependency jar should be bundled", names.contains("dep.jar"));
+    Assert.assertFalse("no empty-named entry should be added", names.contains(""));
+  }
+
+  @Test(expected = FileNotFoundException.class)
+  public void nonBlankMissingPathStillFails() throws Exception {
+    File out = new File(folder.getRoot(), "out.jar");
+
+    // Only empty tokens are skipped; a non-blank path that does not exist must still
+    // fail loudly so a genuinely missing jar is not silently dropped.
+    JarBuilder.main(new String[] {
+        out.getAbsolutePath(), "com.example.Main",
+        new File(folder.getRoot(), "does-not-exist.jar").getAbsolutePath()
+    });
+  }
+}


### PR DESCRIPTION
JarBuilder.main turned every trailing argument into a File, so an empty classpath element — from a leading, trailing, or repeated separator when a classpath string is split into arguments — became `new File("")` and failed with a confusing `FileNotFoundException:  (No such file or directory)`.

Skip blank arguments when parsing the jar list, building the File from the original argument so a path with significant surrounding whitespace is preserved. Non-blank paths that do not exist still fail as before, so a genuinely missing jar is not hidden, and an entirely empty classpath fails fast rather than silently producing a jar with no dependencies.

Adds tests driving main() with empty elements around a real jar and with a non-blank missing path.